### PR TITLE
Backport compatibility tweaks for legacy Python

### DIFF
--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -60,7 +60,7 @@ def create_parser():
         dest='keyword_case',
         choices=_CASE_CHOICES,
         help='change case of keywords, CHOICE is one of {}'.format(
-            ', '.join(f'"{x}"' for x in _CASE_CHOICES)))
+            ', '.join('"{}"'.format(x) for x in _CASE_CHOICES)))
 
     group.add_argument(
         '-i', '--identifiers',
@@ -68,7 +68,7 @@ def create_parser():
         dest='identifier_case',
         choices=_CASE_CHOICES,
         help='change case of identifiers, CHOICE is one of {}'.format(
-            ', '.join(f'"{x}"' for x in _CASE_CHOICES)))
+            ', '.join('"{}"'.format(x) for x in _CASE_CHOICES)))
 
     group.add_argument(
         '-l', '--language',
@@ -157,7 +157,7 @@ def create_parser():
 
 def _error(msg):
     """Print msg and optionally exit with return code exit_."""
-    sys.stderr.write(f'[ERROR] {msg}\n')
+    sys.stderr.write('[ERROR] {}\n'.format(msg))
     return 1
 
 
@@ -177,7 +177,7 @@ def main(args=None):
                 data = ''.join(f.readlines())
         except OSError as e:
             return _error(
-                f'Failed to read {args.filename}: {e}')
+                'Failed to read {}: {}'.format(args.filename, e))
 
     close_stream = False
     if args.outfile:
@@ -185,7 +185,7 @@ def main(args=None):
             stream = open(args.outfile, 'w', encoding=args.encoding)
             close_stream = True
         except OSError as e:
-            return _error(f'Failed to open {args.outfile}: {e}')
+            return _error('Failed to open {}: {}'.format(args.outfile, e))
     else:
         stream = sys.stdout
 
@@ -193,7 +193,7 @@ def main(args=None):
     try:
         formatter_opts = sqlparse.formatter.validate_options(formatter_opts)
     except SQLParseError as e:
-        return _error(f'Invalid options: {e}')
+        return _error('Invalid options: {}'.format(e))
 
     s = sqlparse.format(data, **formatter_opts)
     stream.write(s)

--- a/sqlparse/engine/filter_stack.py
+++ b/sqlparse/engine/filter_stack.py
@@ -47,5 +47,7 @@ class FilterStack:
                     stmt = filter_.process(stmt)
 
                 yield stmt
-        except RecursionError as err:
-            raise SQLParseError('Maximum recursion depth exceeded') from err
+        except RuntimeError as err:
+            if 'maximum recursion depth exceeded' in str(err).lower():
+                raise SQLParseError('Maximum recursion depth exceeded')
+            raise

--- a/sqlparse/filters/aligned_indent.py
+++ b/sqlparse/filters/aligned_indent.py
@@ -126,7 +126,7 @@ class AlignedIndentFilter:
                 self._process(sgroup)
 
     def _process(self, tlist):
-        func_name = f'_process_{type(tlist).__name__}'
+        func_name = '_process_{cls}'.format(cls=type(tlist).__name__)
         func = getattr(self, func_name.lower(), self._process_default)
         func(tlist)
 

--- a/sqlparse/filters/others.py
+++ b/sqlparse/filters/others.py
@@ -81,7 +81,7 @@ class StripCommentsFilter:
 
 class StripWhitespaceFilter:
     def _stripws(self, tlist):
-        func_name = f'_stripws_{type(tlist).__name__}'
+        func_name = '_stripws_{cls}'.format(cls=type(tlist).__name__)
         func = getattr(self, func_name.lower(), self._stripws_default)
         func(tlist)
 

--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -97,7 +97,7 @@ class ReindentFilter:
             tidx, token = tlist.token_next_by(t=ttypes, idx=tidx)
 
     def _process(self, tlist):
-        func_name = f'_process_{type(tlist).__name__}'
+        func_name = '_process_{cls}'.format(cls=type(tlist).__name__)
         func = getattr(self, func_name.lower(), self._process_default)
         func(tlist)
 

--- a/sqlparse/filters/right_margin.py
+++ b/sqlparse/filters/right_margin.py
@@ -37,7 +37,7 @@ class RightMarginFilter:
                         indent = match.group()
                     else:
                         indent = ''
-                    yield sql.Token(T.Whitespace, f'\n{indent}')
+                    yield sql.Token(T.Whitespace, '\n{}'.format(indent))
                     self.line = indent
                 self.line += val
             yield token

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -189,7 +189,7 @@ class TokenList(Token):
             pre = '`- ' if last else '|- '
 
             q = '"' if value.startswith("'") and value.endswith("'") else "'"
-            print(f"{_pre}{pre}{idx} {cls} {q}{value}{q}", file=f)
+            print("{_pre}{pre}{idx} {cls} {q}{value}{q}".format(**locals()), file=f)
 
             if token.is_group and (max_depth is None or depth < max_depth):
                 parent_pre = '   ' if last else '|  '
@@ -211,7 +211,8 @@ class TokenList(Token):
         """
         for token in self.tokens:
             if token.is_group:
-                yield from token.flatten()
+                for t in token.flatten():
+                    yield t
             else:
                 yield token
 


### PR DESCRIPTION
## Summary
- replace f-strings with `str.format` across CLI and filters
- avoid `RecursionError` and `yield from` for Python 3.2 compatibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68978ac3f6e88326b8612f9a780cd349