### PR TITLE
feat: add dialect support with selectable lexers

### DIFF
--- a/docs/source/extending.rst
+++ b/docs/source/extending.rst
@@ -74,3 +74,13 @@ a keyword to the lexer:
 
     # no configuration is passed here. The lexer is used as a singleton.
     sqlparse.parse("select * from foo zorder by bar;")
+
+Selecting built-in dialects
+---------------------------
+
+Sqlparse ships with a set of predefined SQL dialects.  They can be chosen by
+passing a ``dialect`` argument to :func:`sqlparse.parse`,
+:func:`sqlparse.format` or :func:`sqlparse.split`.  The command line interface
+``sqlformat`` exposes the same feature via the ``--dialect`` (or ``--flavor``)
+option.  The default dialect is ``flexible`` which resembles the historical
+behaviour of :mod:`sqlparse`.

--- a/docs/source/ui.rst
+++ b/docs/source/ui.rst
@@ -5,6 +5,8 @@ User Interfaces
   The ``sqlformat`` command line script ist distributed with the module.
   Run :command:`sqlformat --help` to list available options and for usage
   hints.
+  It understands a ``--dialect`` (or ``--flavor``) option which selects the
+  SQL dialect to be used.
 
 ``sqlformat.appspot.com``
   An example `Google App Engine <https://cloud.google.com/appengine/>`_

--- a/docs/sqlformat.1
+++ b/docs/sqlformat.1
@@ -53,6 +53,10 @@ Default is 2 spaces.
 The column limit for wrapping comma-separated lists. If unspecified, it
 puts every item in the list on its own line.
 .TP
+\fB\-\-dialect\fR=\fINAME\fR
+Select SQL dialect to be used when parsing. The option \fB\-\-flavor\fR
+is a synonym. Default is "flexible".
+.TP
 \fB\-\-strip\-comments
 Remove comments.
 .TP

--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -21,24 +21,24 @@ __version__ = '0.5.3'
 __all__ = ['engine', 'filters', 'formatter', 'sql', 'tokens', 'cli', 'config']
 
 
-def parse(sql, encoding=None):
+def parse(sql, encoding=None, dialect=None):
     """Parse sql and return a list of statements.
 
     :param sql: A string containing one or more SQL statements.
     :param encoding: The encoding of the statement (optional).
     :returns: A tuple of :class:`~sqlparse.sql.Statement` instances.
     """
-    return tuple(parsestream(sql, encoding))
+    return tuple(parsestream(sql, encoding, dialect))
 
 
-def parsestream(stream, encoding=None):
+def parsestream(stream, encoding=None, dialect=None):
     """Parses sql statements from file-like object.
 
     :param stream: A file-like object.
     :param encoding: The encoding of the stream contents (optional).
     :returns: A generator of :class:`~sqlparse.sql.Statement` instances.
     """
-    stack = engine.FilterStack()
+    stack = engine.FilterStack(dialect=dialect)
     stack.enable_grouping()
     return stack.run(stream, encoding)
 
@@ -53,14 +53,15 @@ def format(sql, encoding=None, **options):
 
     :returns: The formatted SQL statement as string.
     """
-    stack = engine.FilterStack()
+    dialect = options.pop('dialect', None)
+    stack = engine.FilterStack(dialect=dialect)
     options = formatter.validate_options(options)
     stack = formatter.build_filter_stack(stack, options)
     stack.postprocess.append(filters.SerializerUnicode())
     return ''.join(stack.run(sql, encoding))
 
 
-def split(sql, encoding=None, strip_semicolon=False):
+def split(sql, encoding=None, dialect=None, strip_semicolon=False):
     """Split *sql* into single statements.
 
     :param sql: A string containing one or more SQL statements.
@@ -69,5 +70,5 @@ def split(sql, encoding=None, strip_semicolon=False):
         (default: False).
     :returns: A list of strings.
     """
-    stack = engine.FilterStack(strip_semicolon=strip_semicolon)
+    stack = engine.FilterStack(dialect=dialect, strip_semicolon=strip_semicolon)
     return [str(stmt).strip() for stmt in stack.run(sql, encoding)]

--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -170,6 +170,13 @@ def create_parser():
         default='utf-8',
         help='Specify the input encoding (default utf-8)')
 
+    group.add_argument(
+        '--dialect', '--flavor',
+        dest='dialect',
+        metavar='DIALECT',
+        default=None,
+        help='Specify SQL dialect (default flexible)')
+
     return parser
 
 

--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -9,6 +9,7 @@ except Exception:  # pragma: no cover
 
 # Default style options in internal (snake_case) names
 DEFAULT_CONFIG = {
+    'dialect': 'default',
     'keyword_case': None,
     'identifier_case': None,
     'output_format': None,
@@ -38,6 +39,8 @@ PREDEFINED_STYLES = {
 
 # Mapping from config file keys to internal names
 KEY_MAP = {
+    'Dialect': 'dialect',
+    'Flavor': 'dialect',
     'KeywordCase': 'keyword_case',
     'IdentifierCase': 'identifier_case',
     'OutputFormat': 'output_format',

--- a/sqlparse/dialects/__init__.py
+++ b/sqlparse/dialects/__init__.py
@@ -1,0 +1,25 @@
+"""Builtin SQL dialect plugins."""
+
+# Import modules to register bundled dialects.
+from . import default  # noqa: F401
+from . import ansi  # noqa: F401
+from . import oracle  # noqa: F401
+from . import mysql  # noqa: F401
+from . import postgres  # noqa: F401
+from . import microsoft  # noqa: F401
+from . import sqlite  # noqa: F401
+from . import bigquery  # noqa: F401
+from . import snowflake  # noqa: F401
+
+__all__ = [
+    'default',
+    'ansi',
+    'oracle',
+    'mysql',
+    'postgres',
+    'microsoft',
+    'sqlite',
+    'bigquery',
+    'snowflake',
+]
+

--- a/sqlparse/dialects/ansi.py
+++ b/sqlparse/dialects/ansi.py
@@ -1,0 +1,9 @@
+from sqlparse.lexer import Lexer
+
+
+def initialize(lex):
+    lex._init_with()
+
+
+Lexer.register_dialect('ansi', initialize, aliases=('ansi-sql',))
+

--- a/sqlparse/dialects/bigquery.py
+++ b/sqlparse/dialects/bigquery.py
@@ -1,0 +1,12 @@
+from sqlparse import keywords
+from sqlparse.lexer import Lexer
+
+
+def initialize(lex):
+    lex._init_with(keywords.KEYWORDS_BIGQUERY)
+
+
+Lexer.register_dialect(
+    'bigquery', initialize, aliases=('google', 'bigquery-sql')
+)
+

--- a/sqlparse/dialects/default.py
+++ b/sqlparse/dialects/default.py
@@ -1,0 +1,20 @@
+from sqlparse import keywords
+from sqlparse.lexer import Lexer
+
+
+def initialize(lex):
+    lex.clear()
+    lex.set_SQL_REGEX(keywords.SQL_REGEX)
+    lex.add_keywords(keywords.KEYWORDS_COMMON)
+    lex.add_keywords(keywords.KEYWORDS_ORACLE)
+    lex.add_keywords(keywords.KEYWORDS_MYSQL)
+    lex.add_keywords(keywords.KEYWORDS_PLPGSQL)
+    lex.add_keywords(keywords.KEYWORDS_HQL)
+    lex.add_keywords(keywords.KEYWORDS_MSACCESS)
+    lex.add_keywords(keywords.KEYWORDS_SNOWFLAKE)
+    lex.add_keywords(keywords.KEYWORDS_BIGQUERY)
+    lex.add_keywords(keywords.KEYWORDS)
+
+
+Lexer.register_dialect('default', initialize, aliases=('flexible',))
+

--- a/sqlparse/dialects/microsoft.py
+++ b/sqlparse/dialects/microsoft.py
@@ -1,0 +1,12 @@
+from sqlparse import keywords
+from sqlparse.lexer import Lexer
+
+
+def initialize(lex):
+    lex._init_with(keywords.KEYWORDS_MSACCESS)
+
+
+Lexer.register_dialect(
+    'microsoft', initialize, aliases=('t-sql', 'transact-sql')
+)
+

--- a/sqlparse/dialects/mysql.py
+++ b/sqlparse/dialects/mysql.py
@@ -1,0 +1,12 @@
+from sqlparse import keywords
+from sqlparse.lexer import Lexer
+
+
+def initialize(lex):
+    lex._init_with(keywords.KEYWORDS_MYSQL)
+
+
+Lexer.register_dialect(
+    'mysql', initialize, aliases=('mariadb', 'mariadb-sql')
+)
+

--- a/sqlparse/dialects/oracle.py
+++ b/sqlparse/dialects/oracle.py
@@ -1,0 +1,10 @@
+from sqlparse import keywords
+from sqlparse.lexer import Lexer
+
+
+def initialize(lex):
+    lex._init_with(keywords.KEYWORDS_ORACLE)
+
+
+Lexer.register_dialect('oracle', initialize, aliases=('plsql',))
+

--- a/sqlparse/dialects/postgres.py
+++ b/sqlparse/dialects/postgres.py
@@ -1,0 +1,13 @@
+from sqlparse import keywords
+from sqlparse.lexer import Lexer
+
+
+def initialize(lex):
+    lex._init_with(keywords.KEYWORDS_PLPGSQL)
+
+
+Lexer.register_dialect(
+    'postgres', initialize,
+    aliases=('postgres-sql', 'postgresql', 'postgresql-sql')
+)
+

--- a/sqlparse/dialects/snowflake.py
+++ b/sqlparse/dialects/snowflake.py
@@ -1,0 +1,10 @@
+from sqlparse import keywords
+from sqlparse.lexer import Lexer
+
+
+def initialize(lex):
+    lex._init_with(keywords.KEYWORDS_SNOWFLAKE)
+
+
+Lexer.register_dialect('snowflake', initialize, aliases=('snowflake-sql',))
+

--- a/sqlparse/dialects/sqlite.py
+++ b/sqlparse/dialects/sqlite.py
@@ -1,0 +1,9 @@
+from sqlparse.lexer import Lexer
+
+
+def initialize(lex):
+    lex._init_with()
+
+
+Lexer.register_dialect('sqlite', initialize, aliases=('sqlite-sql',))
+

--- a/sqlparse/engine/filter_stack.py
+++ b/sqlparse/engine/filter_stack.py
@@ -15,11 +15,12 @@ from sqlparse.filters import StripTrailingSemicolonFilter
 
 
 class FilterStack:
-    def __init__(self, strip_semicolon=False):
+    def __init__(self, dialect=None, strip_semicolon=False):
         self.preprocess = []
         self.stmtprocess = []
         self.postprocess = []
         self._grouping = False
+        self._dialect = dialect
         if strip_semicolon:
             self.stmtprocess.append(StripTrailingSemicolonFilter())
 
@@ -28,7 +29,7 @@ class FilterStack:
 
     def run(self, sql, encoding=None):
         try:
-            stream = lexer.tokenize(sql, encoding)
+            stream = lexer.tokenize(sql, encoding, self._dialect)
             # Process token stream
             for filter_ in self.preprocess:
                 stream = filter_.process(stream)

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -24,8 +24,17 @@ class Lexer:
     """The Lexer supports configurable syntax.
     To add support for additional keywords, use the `add_keywords` method."""
 
-    _default_instance = None
+    _instances = {}
     _lock = Lock()
+    _dialects = {}
+    _aliases = {}
+
+    @classmethod
+    def register_dialect(cls, name, initializer, aliases=()):
+        name = name.lower()
+        cls._dialects[name] = initializer
+        for alias in aliases:
+            cls._aliases[alias.lower()] = name
 
     # Development notes:
     # - This class is prepared to be able to support additional SQL dialects
@@ -46,29 +55,41 @@ class Lexer:
     #   default_instance part needing to change interface.
 
     @classmethod
+    def get_instance(cls, dialect='default'):
+        """Return a lexer instance initialized for *dialect*."""
+        name = cls._aliases.get((dialect or 'default').lower(),
+                                (dialect or 'default').lower())
+        with cls._lock:
+            inst = cls._instances.get(name)
+            if inst is None:
+                inst = cls()
+                init = cls._dialects.get(name)
+                if init is None:
+                    raise ValueError("Unknown dialect: %s" % name)
+                init(inst)
+                cls._instances[name] = inst
+            return inst
+
+    @classmethod
     def get_default_instance(cls):
         """Returns the lexer instance used internally
         by the sqlparse core functions."""
-        with cls._lock:
-            if cls._default_instance is None:
-                cls._default_instance = cls()
-                cls._default_instance.default_initialization()
-        return cls._default_instance
+        return cls.get_instance('default')
 
-    def default_initialization(self):
-        """Initialize the lexer with default dictionaries.
-        Useful if you need to revert custom syntax settings."""
+    def _init_with(self, *kwdicts):
+        """Helper to initialize lexer with common regex and keywords."""
         self.clear()
         self.set_SQL_REGEX(keywords.SQL_REGEX)
         self.add_keywords(keywords.KEYWORDS_COMMON)
-        self.add_keywords(keywords.KEYWORDS_ORACLE)
-        self.add_keywords(keywords.KEYWORDS_MYSQL)
-        self.add_keywords(keywords.KEYWORDS_PLPGSQL)
-        self.add_keywords(keywords.KEYWORDS_HQL)
-        self.add_keywords(keywords.KEYWORDS_MSACCESS)
-        self.add_keywords(keywords.KEYWORDS_SNOWFLAKE)
-        self.add_keywords(keywords.KEYWORDS_BIGQUERY)
+        for kw in kwdicts:
+            self.add_keywords(kw)
         self.add_keywords(keywords.KEYWORDS)
+
+    def default_initialization(self):
+        init = self.__class__._dialects.get('default')
+        if init is None:
+            raise ValueError('Unknown dialect: default')
+        init(self)
 
     def clear(self):
         """Clear all syntax configurations.
@@ -151,11 +172,26 @@ class Lexer:
             else:
                 yield tokens.Error, char
 
+try:
+    import sqlparse.dialects  # noqa: F401
+except Exception:
+    pass
 
-def tokenize(sql, encoding=None):
+try:
+    import pkg_resources
+    for ep in pkg_resources.iter_entry_points('sqlparse.dialect'):
+        try:
+            ep.load()
+        except Exception:
+            pass
+except Exception:
+    pass
+
+
+def tokenize(sql, encoding=None, dialect=None):
     """Tokenize sql.
 
     Tokenize *sql* using the :class:`Lexer` and return a 2-tuple stream
     of ``(token type, value)`` items.
     """
-    return Lexer.get_default_instance().get_tokens(sql, encoding)
+    return Lexer.get_instance(dialect).get_tokens(sql, encoding)

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -1,0 +1,10 @@
+import sqlparse
+from sqlparse import lexer, tokens as T
+
+
+def test_ansi_vs_postgres_keyword():
+    sql = 'PERFORM 1'
+    tokens_ansi = list(lexer.tokenize(sql, dialect='ansi'))
+    assert tokens_ansi[0][0] is T.Name
+    tokens_pg = list(lexer.tokenize(sql, dialect='postgres'))
+    assert tokens_pg[0][0] is T.Keyword


### PR DESCRIPTION
## Summary
- add interchangeable lexer instances with aliases for common SQL dialects
- expose `dialect`/`flavor` option in configuration and `sqlformat` CLI
- document dialect usage and provide regression test
- move bundled dialect definitions into plugin modules discoverable by the lexer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689a047cf140832688c4c162524aefc9