### PR TITLE
Ensure SELECT INTO clauses start on new line

### DIFF
--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -54,7 +54,8 @@ class ReindentFilter:
     def _next_token(self, tlist, idx=-1):
         split_words = ('FROM', 'STRAIGHT_JOIN$', 'JOIN$', 'AND', 'OR',
                        'GROUP BY', 'ORDER BY', 'UNION', 'VALUES',
-                       'SET', 'BETWEEN', 'EXCEPT', 'HAVING', 'LIMIT')
+                       'SET', 'BETWEEN', 'EXCEPT', 'HAVING', 'LIMIT',
+                       'INTO')
         m_split = T.Keyword, split_words, True
         tidx, token = tlist.token_next_by(m=m_split, idx=idx)
 
@@ -69,6 +70,12 @@ class ReindentFilter:
     def _split_kwds(self, tlist):
         tidx, token = self._next_token(tlist)
         while token:
+            if token.normalized == 'INTO':
+                _, prev_kw = tlist.token_prev(tidx, skip_ws=True)
+                if prev_kw and prev_kw.normalized == 'INSERT':
+                    tidx, token = self._next_token(tlist, tidx)
+                    continue
+
             pidx, prev_ = tlist.token_prev(tidx, skip_ws=False)
             uprev = str(prev_)
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -638,6 +638,19 @@ class TestFormatReindent:
             '     , (5, 6)'])
 
 
+    def test_select_into(self):
+        f = lambda sql: sqlparse.format(sql, reindent=True)
+        s = ('select first_name, last_name into :firstName, :lastName '
+             'from employees where employee_id = :id;')
+        assert f(s) == '\n'.join([
+            'select first_name,',
+            '       last_name',
+            'into :firstName,',
+            '     :lastName',
+            'from employees',
+            'where employee_id = :id;'])
+
+
 class TestOutputFormat:
     def test_python(self):
         sql = 'select * from foo;'


### PR DESCRIPTION
## Summary
- split `INTO` onto its own line during reindent formatting
- avoid splitting when `INTO` follows `INSERT`
- add regression test for `SELECT ... INTO` formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689a1cda607c8326b14eaf231dfb5c50