### PR TITLE
Handle comments after config values in .sqlparse files

### DIFF
--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -83,6 +83,8 @@ def _parse_simple_yaml(text):
         key, value = line.split(':', 1)
         key = key.strip()
         value = value.strip()
+        if value:
+            value = value.split('#', 1)[0].rstrip()
         while indent < indents[-1]:
             stack.pop()
             indents.pop()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,15 @@ def test_load_config(tmpdir):
     assert options['keyword_case'] == 'upper'
 
 
+def test_load_config_ignores_comments(tmpdir, monkeypatch):
+    monkeypatch.setattr(config, 'yaml', None)
+    cfg_dir = tmpdir.mkdir('cfg_comment')
+    cfg_file = cfg_dir.join('.sqlparse')
+    cfg_file.write('version: 1\nkeywords:\n  case: upper   # comment\n')
+    options = config.load_config(str(cfg_dir))
+    assert options['keyword_case'] == 'upper'
+
+
 def test_dump_config():
     opts = config.DEFAULT_CONFIG.copy()
     opts['keyword_case'] = 'upper'


### PR DESCRIPTION
## Summary
- ensure `_parse_simple_yaml` strips trailing comments and whitespace from option values
- test that `.sqlparse` config handles comment after value when PyYAML is unavailable

## Testing
- `pytest`
- `python -m flake8` *(fails: No module named flake8)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_b_689aa7c6f028832692b6433d70176271