### PR TITLE
Support tsql alias and identifier case preserve option

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -25,12 +25,12 @@ Formatting of SQL Statements
 The :meth:`~sqlparse.format` function accepts the following keyword arguments.
 
 ``keyword_case``
-  Changes how keywords are formatted. Allowed values are "upper", "lower"
-  and "capitalize".
+  Changes how keywords are formatted. Allowed values are "upper", "lower",
+  "capitalize", and "preserve".
 
 ``identifier_case``
   Changes how identifiers are formatted. Allowed values are "upper", "lower",
-  and "capitalize".
+  "capitalize", and "preserve".
 
 ``strip_comments``
   If ``True`` comments are removed from the statements.

--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -32,7 +32,7 @@ from sqlparse.exceptions import SQLParseError
 # TODO: Add CLI Tests
 # TODO: Simplify formatter by using argparse `type` arguments
 def create_parser():
-    _CASE_CHOICES = ['upper', 'lower', 'capitalize']
+    _CASE_CHOICES = ['upper', 'lower', 'capitalize', 'preserve']
 
     parser = argparse.ArgumentParser(
         prog='sqlformat',

--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -195,12 +195,12 @@ def load_clang_config(path):
     if isinstance(keywords, dict):
         case = keywords.get('case')
         if case:
-            opts['keyword_case'] = case
+            opts['keyword_case'] = case.lower()
     identifiers = data.get('identifiers')
     if isinstance(identifiers, dict):
         case = identifiers.get('case')
         if case:
-            opts['identifier_case'] = case
+            opts['identifier_case'] = case.lower()
     return opts
 
 

--- a/sqlparse/dialects/microsoft.py
+++ b/sqlparse/dialects/microsoft.py
@@ -7,6 +7,6 @@ def initialize(lex):
 
 
 Lexer.register_dialect(
-    'microsoft', initialize, aliases=('t-sql', 'transact-sql')
+    'microsoft', initialize, aliases=('t-sql', 'transact-sql', 'tsql')
 )
 

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -13,15 +13,23 @@ from sqlparse.exceptions import SQLParseError
 
 def validate_options(options):  # noqa: C901
     """Validates options."""
-    kwcase = options.get('keyword_case')
+    orig_kwcase = options.get('keyword_case')
+    kwcase = orig_kwcase
+    if kwcase == 'preserve':
+        kwcase = None
     if kwcase not in [None, 'upper', 'lower', 'capitalize']:
         raise SQLParseError('Invalid value for keyword_case: '
-                            '{!r}'.format(kwcase))
+                            '{!r}'.format(orig_kwcase))
+    options['keyword_case'] = kwcase
 
-    idcase = options.get('identifier_case')
+    orig_idcase = options.get('identifier_case')
+    idcase = orig_idcase
+    if idcase == 'preserve':
+        idcase = None
     if idcase not in [None, 'upper', 'lower', 'capitalize']:
         raise SQLParseError('Invalid value for identifier_case: '
-                            '{!r}'.format(idcase))
+                            '{!r}'.format(orig_idcase))
+    options['identifier_case'] = idcase
 
     ofrmt = options.get('output_format')
     if ofrmt not in [None, 'sql', 'python', 'php']:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,3 +38,20 @@ def test_load_clang_config(tmpdir):
     opts = config.load_clang_config(str(cfg))
     assert opts['indent_width'] == 3
     assert opts['keyword_case'] == 'lower'
+
+
+def test_load_config_preserve(tmpdir):
+    cfg_dir = tmpdir.mkdir('cfg_preserve')
+    cfg_file = cfg_dir.join('.sqlparse')
+    cfg_file.write('version: 1\nkeywords:\n  case: preserve\nidentifiers:\n  case: preserve\n')
+    options = config.load_config(str(cfg_dir))
+    assert options['keyword_case'] == 'preserve'
+    assert options['identifier_case'] == 'preserve'
+
+
+def test_load_clang_config_preserve(tmpdir):
+    cfg = tmpdir.join('style_preserve.yaml')
+    cfg.write('version: 1\nkeywords:\n  case: preserve\nidentifiers:\n  case: preserve\n')
+    opts = config.load_clang_config(str(cfg))
+    assert opts['keyword_case'] == 'preserve'
+    assert opts['identifier_case'] == 'preserve'

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -8,3 +8,11 @@ def test_ansi_vs_postgres_keyword():
     assert tokens_ansi[0][0] is T.Name
     tokens_pg = list(lexer.tokenize(sql, dialect='postgres'))
     assert tokens_pg[0][0] is T.Keyword
+
+
+def test_tsql_alias():
+    sql = 'DISTINCTROW'
+    tokens_ansi = list(lexer.tokenize(sql, dialect='ansi'))
+    assert tokens_ansi[0][0] is T.Name
+    tokens_tsql = list(lexer.tokenize(sql, dialect='tsql'))
+    assert tokens_tsql[0][0] is T.Keyword

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -14,6 +14,11 @@ class TestFormat:
         res = sqlparse.format(sql.upper(), keyword_case='lower')
         assert res == 'select * from BAR; -- SELECT FOO\n'
 
+    def test_keywordcase_preserve(self):
+        sql = 'select Foo from bar'
+        res = sqlparse.format(sql, keyword_case='preserve')
+        assert res == sql
+
     def test_keywordcase_invalid_option(self):
         sql = 'select * from bar; -- select foo\n'
         with pytest.raises(SQLParseError):
@@ -27,6 +32,11 @@ class TestFormat:
         assert res == 'select * from Bar; -- select foo\n'
         res = sqlparse.format(sql.upper(), identifier_case='lower')
         assert res == 'SELECT * FROM bar; -- SELECT FOO\n'
+
+    def test_identifiercase_preserve(self):
+        sql = 'select Foo from bar'
+        res = sqlparse.format(sql, identifier_case='preserve')
+        assert res == sql
 
     def test_identifiercase_invalid_option(self):
         sql = 'select * from bar; -- select foo\n'


### PR DESCRIPTION
## Summary
- allow `identifier_case='preserve'` and `keyword_case='preserve'` to skip case normalization
- add `tsql` alias for the Microsoft SQL dialect
- test case preservation and T-SQL alias recognition

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689aaf05b688832688227dd87ad0d9e7