### PR TITLE
feat: expand clang-style config parsing

### DIFF
--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -54,11 +54,18 @@ def format(sql, encoding=None, **options):
     :returns: The formatted SQL statement as string.
     """
     dialect = options.pop('dialect', None)
+    newline_at_eof = options.pop('newline_at_eof', None)
     stack = engine.FilterStack(dialect=dialect)
     options = formatter.validate_options(options)
     stack = formatter.build_filter_stack(stack, options)
     stack.postprocess.append(filters.SerializerUnicode())
-    return ''.join(stack.run(sql, encoding))
+    result = ''.join(stack.run(sql, encoding))
+    if newline_at_eof is True:
+        if not result.endswith('\n'):
+            result += '\n'
+    elif newline_at_eof is False:
+        result = result.rstrip('\n')
+    return result
 
 
 def split(sql, encoding=None, dialect=None, strip_semicolon=False):

--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -20,6 +20,9 @@ DEFAULT_CONFIG = {
     'indent_columns': False,
     'reindent_aligned': False,
     'use_space_around_operators': False,
+    'spaces_in_parens': False,
+    'spaces_in_brackets': False,
+    'space_before_call_paren': False,
     'wrap_after': 0,
     'comma_first': False,
     'compact': False,
@@ -52,6 +55,9 @@ KEY_MAP = {
     'IndentColumns': 'indent_columns',
     'ReindentAligned': 'reindent_aligned',
     'UseSpaceAroundOperators': 'use_space_around_operators',
+    'SpacesInParens': 'spaces_in_parens',
+    'SpacesInBrackets': 'spaces_in_brackets',
+    'SpaceBeforeCallParen': 'space_before_call_paren',
     'WrapAfter': 'wrap_after',
     'CommaFirst': 'comma_first',
     'Compact': 'compact',
@@ -213,7 +219,15 @@ def load_clang_config(path):
     if isinstance(spacing, dict):
         if 'space_around_operators' in spacing:
             opts['use_space_around_operators'] = spacing['space_around_operators']
-        rem = {k: v for k, v in spacing.items() if k != 'space_around_operators'}
+        if 'spaces_in_parens' in spacing:
+            opts['spaces_in_parens'] = spacing['spaces_in_parens']
+        if 'spaces_in_brackets' in spacing:
+            opts['spaces_in_brackets'] = spacing['spaces_in_brackets']
+        if 'space_before_call_paren' in spacing:
+            opts['space_before_call_paren'] = spacing['space_before_call_paren']
+        rem = {k: v for k, v in spacing.items() if k not in (
+            'space_around_operators', 'spaces_in_parens',
+            'spaces_in_brackets', 'space_before_call_paren')}
         if rem:
             opts['spacing'] = rem
 

--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -24,6 +24,7 @@ DEFAULT_CONFIG = {
     'comma_first': False,
     'compact': False,
     'indent_tabs': False,
+    'newline_at_eof': None,
     'strip_whitespace': False,
     'truncate_strings': None,
     'truncate_char': '[...]',

--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -175,32 +175,80 @@ def load_clang_config(path):
     version = data.get('version')
     if version != 1:
         raise ValueError('Unsupported config version: {0}'.format(version))
+
     opts = {}
+
+    # Dialect
     dialect = data.get('dialect')
     if isinstance(dialect, dict):
         mode = dialect.get('mode')
         if mode:
             opts['dialect'] = mode
+        other = {k: v for k, v in dialect.items() if k != 'mode'}
+        if other:
+            opts['dialect_options'] = other
+
+    # Layout options
     layout = data.get('layout')
     if isinstance(layout, dict):
         if 'indent_width' in layout:
             opts['indent_width'] = layout['indent_width']
         if 'column_limit' in layout:
             opts['wrap_after'] = layout['column_limit']
+        if 'use_tab' in layout:
+            use_tab = layout['use_tab']
+            if isinstance(use_tab, str):
+                use_tab = use_tab.lower() != 'never'
+            opts['indent_tabs'] = bool(use_tab)
+        if 'newline_at_eof' in layout:
+            opts['newline_at_eof'] = layout['newline_at_eof']
+        rem = {k: v for k, v in layout.items()
+               if k not in ('indent_width', 'column_limit', 'use_tab', 'newline_at_eof')}
+        if rem:
+            opts['layout'] = rem
+
+    # Spacing rules
     spacing = data.get('spacing')
     if isinstance(spacing, dict):
         if 'space_around_operators' in spacing:
             opts['use_space_around_operators'] = spacing['space_around_operators']
+        rem = {k: v for k, v in spacing.items() if k != 'space_around_operators'}
+        if rem:
+            opts['spacing'] = rem
+
+    # Keyword casing
     keywords = data.get('keywords')
     if isinstance(keywords, dict):
         case = keywords.get('case')
         if case:
             opts['keyword_case'] = case.lower()
+        rem = {k: v for k, v in keywords.items() if k != 'case'}
+        if rem:
+            opts['keywords'] = rem
+
+    # Identifier casing
     identifiers = data.get('identifiers')
     if isinstance(identifiers, dict):
         case = identifiers.get('case')
         if case:
             opts['identifier_case'] = case.lower()
+        rem = {k: v for k, v in identifiers.items() if k != 'case'}
+        if rem:
+            opts['identifiers'] = rem
+
+    # Remaining top-level sections are stored verbatim so callers may
+    # access the detailed formatting instructions defined in the config
+    # file.  They currently don't map to built-in sqlparse options but
+    # are preserved to allow external tools to consume them.
+    for name in (
+        'lists', 'clauses', 'joins', 'predicates', 'case_expr', 'cte',
+        'subqueries', 'blocks', 'declarations', 'create_table',
+        'comments', 'penalties',
+    ):
+        section = data.get(name)
+        if isinstance(section, dict):
+            opts[name] = section
+
     return opts
 
 

--- a/sqlparse/filters/__init__.py
+++ b/sqlparse/filters/__init__.py
@@ -10,6 +10,7 @@ from sqlparse.filters.others import StripCommentsFilter
 from sqlparse.filters.others import StripWhitespaceFilter
 from sqlparse.filters.others import StripTrailingSemicolonFilter
 from sqlparse.filters.others import SpacesAroundOperatorsFilter
+from sqlparse.filters.others import ParenSpacingFilter
 
 from sqlparse.filters.output import OutputPHPFilter
 from sqlparse.filters.output import OutputPythonFilter
@@ -28,6 +29,7 @@ __all__ = [
     'StripWhitespaceFilter',
     'StripTrailingSemicolonFilter',
     'SpacesAroundOperatorsFilter',
+    'ParenSpacingFilter',
 
     'OutputPHPFilter',
     'OutputPythonFilter',

--- a/sqlparse/filters/others.py
+++ b/sqlparse/filters/others.py
@@ -128,6 +128,66 @@ class StripWhitespaceFilter:
         return stmt
 
 
+class ParenSpacingFilter:
+    """Apply spacing rules around parentheses, brackets and function calls."""
+
+    def __init__(self, spaces_in_parens=False, spaces_in_brackets=False,
+                 space_before_call_paren=False):
+        self.spaces_in_parens = spaces_in_parens
+        self.spaces_in_brackets = spaces_in_brackets
+        self.space_before_call_paren = space_before_call_paren
+
+    def _pad(self, group, want_space):
+        if len(group.tokens) <= 2:
+            return
+        if want_space:
+            if not group.tokens[1].is_whitespace:
+                group.tokens.insert(1, sql.Token(T.Whitespace, ' '))
+            else:
+                group.tokens[1].value = ' '
+            if not group.tokens[-2].is_whitespace:
+                group.tokens.insert(-1, sql.Token(T.Whitespace, ' '))
+            else:
+                group.tokens[-2].value = ' '
+        else:
+            while len(group.tokens) > 2 and group.tokens[1].is_whitespace:
+                group.tokens.pop(1)
+            while len(group.tokens) > 2 and group.tokens[-2].is_whitespace:
+                group.tokens.pop(-2)
+
+    def _process(self, tlist):
+        for token in list(tlist.tokens):
+            if token.is_group:
+                self._process(token)
+            elif self.spaces_in_brackets:
+                val = token.value
+                if isinstance(val, str) and val.startswith('[') and val.endswith(']'):
+                    inner = val[1:-1].strip()
+                    if self.spaces_in_brackets:
+                        token.value = '[ ' + inner + ' ]'
+                    else:
+                        token.value = '[' + inner + ']'
+
+        if self.space_before_call_paren and isinstance(tlist, sql.Function):
+            res = tlist.token_next_by(i=sql.Parenthesis)
+            if res:
+                idx = tlist.token_index(res[1])
+                prev_ = tlist.tokens[idx - 1]
+                if not prev_.is_whitespace:
+                    tlist.insert_before(idx, sql.Token(T.Whitespace, ' '))
+                else:
+                    prev_.value = ' '
+
+        if isinstance(tlist, sql.Parenthesis):
+            self._pad(tlist, self.spaces_in_parens)
+        elif isinstance(tlist, sql.SquareBrackets):
+            self._pad(tlist, self.spaces_in_brackets)
+
+    def process(self, stmt):
+        self._process(stmt)
+        return stmt
+
+
 class SpacesAroundOperatorsFilter:
     @staticmethod
     def _process(tlist):

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -46,6 +46,24 @@ def validate_options(options):  # noqa: C901
         raise SQLParseError('Invalid value for use_space_around_operators: '
                             '{!r}'.format(space_around_operators))
 
+    spaces_in_parens = options.get('spaces_in_parens', False)
+    if spaces_in_parens not in [True, False]:
+        raise SQLParseError('Invalid value for spaces_in_parens: '
+                            '{!r}'.format(spaces_in_parens))
+    options['spaces_in_parens'] = spaces_in_parens
+
+    spaces_in_brackets = options.get('spaces_in_brackets', False)
+    if spaces_in_brackets not in [True, False]:
+        raise SQLParseError('Invalid value for spaces_in_brackets: '
+                            '{!r}'.format(spaces_in_brackets))
+    options['spaces_in_brackets'] = spaces_in_brackets
+
+    space_before_call_paren = options.get('space_before_call_paren', False)
+    if space_before_call_paren not in [True, False]:
+        raise SQLParseError('Invalid value for space_before_call_paren: '
+                            '{!r}'.format(space_before_call_paren))
+    options['space_before_call_paren'] = space_before_call_paren
+
     strip_ws = options.get('strip_whitespace', False)
     if strip_ws not in [True, False]:
         raise SQLParseError('Invalid value for strip_whitespace: '
@@ -180,6 +198,15 @@ def build_filter_stack(stack, options):
     if options.get('strip_whitespace') or options.get('reindent'):
         stack.enable_grouping()
         stack.stmtprocess.append(filters.StripWhitespaceFilter())
+
+    if (options.get('spaces_in_parens') or options.get('spaces_in_brackets') or
+            options.get('space_before_call_paren')):
+        stack.enable_grouping()
+        stack.stmtprocess.append(
+            filters.ParenSpacingFilter(
+                spaces_in_parens=options.get('spaces_in_parens'),
+                spaces_in_brackets=options.get('spaces_in_brackets'),
+                space_before_call_paren=options.get('space_before_call_paren')))
 
     if options.get('reindent'):
         stack.enable_grouping()

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -101,6 +101,12 @@ def validate_options(options):  # noqa: C901
     else:
         options['indent_char'] = ' '
 
+    newline_at_eof = options.get('newline_at_eof', None)
+    if newline_at_eof not in [None, True, False]:
+        raise SQLParseError('Invalid value for newline_at_eof: '
+                            '{!r}'.format(newline_at_eof))
+    options['newline_at_eof'] = newline_at_eof
+
     indent_width = options.get('indent_width', 2)
     try:
         indent_width = int(indent_width)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,3 +55,66 @@ def test_load_clang_config_preserve(tmpdir):
     opts = config.load_clang_config(str(cfg))
     assert opts['keyword_case'] == 'preserve'
     assert opts['identifier_case'] == 'preserve'
+
+
+def test_load_clang_config_full_sections(tmpdir):
+    cfg = tmpdir.join('style_full.yaml')
+    cfg.write(
+        'version: 1\n'
+        'layout:\n'
+        '  indent_width: 4\n'
+        '  use_tab: always\n'
+        'spacing:\n'
+        '  spaces_in_parens: true\n'
+        'keywords:\n'
+        '  case: upper\n'
+        '  reserved_only: true\n'
+        'identifiers:\n'
+        '  case: lower\n'
+        '  quote_style: single\n'
+        'lists:\n'
+        '  bin_pack: true\n'
+        'clauses:\n'
+        '  break:\n'
+        '    select: before\n'
+        'joins:\n'
+        '  join_on_new_line: true\n'
+        'predicates:\n'
+        '  layout: compact\n'
+        'case_expr:\n'
+        '  indent_when_then: false\n'
+        'cte:\n'
+        '  one_per_line: false\n'
+        'subqueries:\n'
+        '  open_paren_same_line: false\n'
+        'blocks:\n'
+        '  begin_same_line: false\n'
+        'declarations:\n'
+        '  one_per_line: true\n'
+        'create_table:\n'
+        '  align_columns: false\n'
+        'comments:\n'
+        '  preserve_comment_position: true\n'
+        'penalties:\n'
+        '  over_column_limit: 500\n'
+    )
+    opts = config.load_clang_config(str(cfg))
+    assert opts['indent_width'] == 4
+    assert opts['indent_tabs'] is True
+    assert opts['spacing']['spaces_in_parens'] is True
+    assert opts['keyword_case'] == 'upper'
+    assert opts['keywords']['reserved_only'] is True
+    assert opts['identifier_case'] == 'lower'
+    assert opts['identifiers']['quote_style'] == 'single'
+    assert opts['lists']['bin_pack'] is True
+    assert opts['clauses']['break']['select'] == 'before'
+    assert opts['joins']['join_on_new_line'] is True
+    assert opts['predicates']['layout'] == 'compact'
+    assert opts['case_expr']['indent_when_then'] is False
+    assert opts['cte']['one_per_line'] is False
+    assert opts['subqueries']['open_paren_same_line'] is False
+    assert opts['blocks']['begin_same_line'] is False
+    assert opts['declarations']['one_per_line'] is True
+    assert opts['create_table']['align_columns'] is False
+    assert opts['comments']['preserve_comment_position'] is True
+    assert opts['penalties']['over_column_limit'] == 500

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,13 @@ def test_load_clang_config(tmpdir):
     assert opts['keyword_case'] == 'lower'
 
 
+def test_load_clang_config_newline_at_eof(tmpdir):
+    cfg = tmpdir.join('newline.yaml')
+    cfg.write('version: 1\nlayout:\n  newline_at_eof: true\n')
+    opts = config.load_clang_config(str(cfg))
+    assert opts['newline_at_eof'] is True
+
+
 def test_load_config_preserve(tmpdir):
     cfg_dir = tmpdir.mkdir('cfg_preserve')
     cfg_file = cfg_dir.join('.sqlparse')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -108,7 +108,7 @@ def test_load_clang_config_full_sections(tmpdir):
     opts = config.load_clang_config(str(cfg))
     assert opts['indent_width'] == 4
     assert opts['indent_tabs'] is True
-    assert opts['spacing']['spaces_in_parens'] is True
+    assert opts['spaces_in_parens'] is True
     assert opts['keyword_case'] == 'upper'
     assert opts['keywords']['reserved_only'] is True
     assert opts['identifier_case'] == 'lower'

--- a/tests/test_formatter_config.py
+++ b/tests/test_formatter_config.py
@@ -7,10 +7,14 @@ def test_format_applies_clang_config(tmpdir):
         'version: 1\n'
         'dialect:\n  mode: postgres\n'
         'layout:\n  newline_at_eof: true\n'
-        'spacing:\n  space_around_operators: true\n'
+        'spacing:\n'
+        '  space_around_operators: true\n'
+        '  spaces_in_parens: true\n'
+        '  spaces_in_brackets: true\n'
+        '  space_before_call_paren: true\n'
         'keywords:\n  case: upper\n'
         'identifiers:\n  case: lower\n'
     )
     opts = config.load_config(str(tmpdir))
-    formatted = sqlparse.format('perform Foo+1', **opts)
-    assert formatted == 'PERFORM foo + 1\n'
+    formatted = sqlparse.format('perform Foo(1+1), [Bar]', **opts)
+    assert formatted == 'PERFORM foo ( 1 + 1 ), [ bar ]\n'

--- a/tests/test_formatter_config.py
+++ b/tests/test_formatter_config.py
@@ -1,0 +1,16 @@
+import sqlparse
+from sqlparse import config
+
+def test_format_applies_clang_config(tmpdir):
+    cfg = tmpdir.join('.sqlparse')
+    cfg.write(
+        'version: 1\n'
+        'dialect:\n  mode: postgres\n'
+        'layout:\n  newline_at_eof: true\n'
+        'spacing:\n  space_around_operators: true\n'
+        'keywords:\n  case: upper\n'
+        'identifiers:\n  case: lower\n'
+    )
+    opts = config.load_config(str(tmpdir))
+    formatted = sqlparse.format('perform Foo+1', **opts)
+    assert formatted == 'PERFORM foo + 1\n'


### PR DESCRIPTION
## Summary
- parse entire clang-style YAML spec and expose all sections
- map common options (layout, spacing, keywords, identifiers) to existing sqlparse flags
- test full-section parsing via comprehensive configuration file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ab88c6cc88326a101d03fa1e21ecb