### PR TITLE
Add dialect strictness plugin with continuation indent support

### DIFF
--- a/doc/Configuration-Options-Thus-Far.md
+++ b/doc/Configuration-Options-Thus-Far.md
@@ -2,12 +2,12 @@
 
 ## dialect
 - mode: implemented
-- strict_keywords: not implemented
+- strict_keywords: implemented
 
 ## layout
 - column_limit: implemented
 - indent_width: implemented
-- continuation_indent: not implemented
+- continuation_indent: implemented
 - use_tab: implemented
 - newline_at_eof: implemented
 

--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -57,6 +57,7 @@ def format(sql, encoding=None, **options):
     newline_at_eof = options.pop('newline_at_eof', None)
     stack = engine.FilterStack(dialect=dialect)
     options = formatter.validate_options(options)
+    options['dialect'] = dialect
     stack = formatter.build_filter_stack(stack, options)
     stack.postprocess.append(filters.SerializerUnicode())
     result = ''.join(stack.run(sql, encoding))

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -8,7 +8,19 @@
 """SQL formatter"""
 
 from sqlparse import filters
+from sqlparse import plugins
 from sqlparse.exceptions import SQLParseError
+
+
+class _PluginFilter(object):
+    """Adapter to run formatter plugins within the filter stack."""
+
+    def __init__(self, plugin, options):
+        self._plugin = plugin
+        self._options = options
+
+    def process(self, stream):
+        return self._plugin.format(stream, self._options)
 
 
 def validate_options(options):  # noqa: C901
@@ -241,5 +253,16 @@ def build_filter_stack(stack, options):
             fltr = None
         if fltr is not None:
             stack.postprocess.append(fltr)
+
+    # Registered plugins
+    for name in plugins.available_plugins():
+        plugin_cls = plugins.get_plugin(name)
+        if plugin_cls is None:
+            continue
+        plugin = plugin_cls()
+        # Preprocess filters should run before builtins
+        stack.preprocess.insert(0, _PluginFilter(plugin, options))
+        # Postprocess filters run before serialization
+        stack.postprocess.append(_PluginFilter(plugin, options))
 
     return stack

--- a/sqlparse/plugins/__init__.py
+++ b/sqlparse/plugins/__init__.py
@@ -9,14 +9,14 @@ shared state.
 _registry = {}
 
 
-def register_plugin(name, plugin_cls):
-    """Register *plugin_cls* under *name*.
+def register_plugin(name):
+    """Decorator to register *plugin_cls* under *name*."""
 
-    If a plugin with *name* already exists it will be replaced.
-    The function returns the class to allow usage as a decorator.
-    """
-    _registry[name] = plugin_cls
-    return plugin_cls
+    def _inner(plugin_cls):
+        _registry[name] = plugin_cls
+        return plugin_cls
+
+    return _inner
 
 
 def get_plugin(name):
@@ -30,3 +30,10 @@ def get_plugin(name):
 def available_plugins():
     """Return an iterable of registered plugin names."""
     return _registry.keys()
+
+
+# Import bundled plugins
+try:
+    from . import dialect_strictness  # noqa: F401
+except Exception:
+    pass

--- a/sqlparse/plugins/dialect_strictness.py
+++ b/sqlparse/plugins/dialect_strictness.py
@@ -1,0 +1,76 @@
+from sqlparse import plugins, keywords, tokens as T
+
+@plugins.register_plugin('dialect_strictness')
+class DialectStrictness(object):
+    """Handle dialect.strict_keywords and layout.continuation_indent."""
+
+    def format(self, stream, options):
+        if hasattr(stream, 'token_next'):
+            return self._postprocess(stream, options)
+        return self._preprocess(stream, options)
+
+    def _preprocess(self, stream, options):
+        strict = False
+        dialect_opts = options.get('dialect_options') or {}
+        if 'strict_keywords' in dialect_opts:
+            strict = dialect_opts['strict_keywords']
+        if not strict:
+            for item in stream:
+                yield item
+            return
+        dialect = options.get('dialect')
+        allowed = {}
+        allowed.update(keywords.KEYWORDS_COMMON)
+        if dialect:
+            name = 'KEYWORDS_{0}'.format(str(dialect).upper())
+            kw = getattr(keywords, name, {})
+            allowed.update(kw)
+        else:
+            allowed.update(keywords.KEYWORDS)
+        allowed_keys = set(allowed.keys())
+        for ttype, value in stream:
+            if ttype in T.Keyword and value.upper() not in allowed_keys:
+                yield T.Name, value
+            else:
+                yield ttype, value
+
+    def _postprocess(self, stmt, options):
+        layout = options.get('layout') or {}
+        cont = layout.get('continuation_indent')
+        if not cont:
+            return stmt
+        try:
+            cont = int(cont)
+        except Exception:
+            return stmt
+        indent_width = options.get('indent_width', 2)
+        tokens = list(stmt.flatten())
+        level = 0
+        i = 0
+        length = len(tokens)
+        while i < length:
+            tok = tokens[i]
+            if tok.match(T.Punctuation, '('):
+                level += 1
+            elif tok.match(T.Punctuation, ')'):
+                if level:
+                    level -= 1
+            elif tok.is_whitespace and '\n' in tok.value:
+                j = i + 1
+                next_tok = None
+                while j < length:
+                    nt = tokens[j]
+                    if not nt.is_whitespace:
+                        next_tok = nt
+                        break
+                    j += 1
+                if next_tok is None:
+                    i += 1
+                    continue
+                if next_tok.ttype in T.Keyword:
+                    indent = indent_width * level
+                else:
+                    indent = indent_width * level + cont
+                tok.value = '\n' + ' ' * indent
+            i += 1
+        return stmt

--- a/tests/test_dialect_strictness.py
+++ b/tests/test_dialect_strictness.py
@@ -1,0 +1,23 @@
+import sqlparse
+
+
+def test_strict_keywords():
+    sql = 'select fetch from dual'
+    res = sqlparse.format(sql, keyword_case='upper', dialect='oracle')
+    assert res == 'SELECT FETCH FROM dual'
+    res = sqlparse.format(
+        sql,
+        keyword_case='upper',
+        dialect='oracle',
+        dialect_options={'strict_keywords': True})
+    assert res == 'SELECT fetch FROM dual'
+
+
+def test_continuation_indent():
+    sql = 'select foo, bar, baz from dual'
+    res = sqlparse.format(
+        sql,
+        reindent=True,
+        wrap_after=14,
+        layout={'continuation_indent': 4})
+    assert res == 'select foo, bar,\n    baz\nfrom dual'


### PR DESCRIPTION
## Summary
- support `dialect.strict_keywords` to limit keyword casing to the active dialect
- add `layout.continuation_indent` option for wrapped line indentation
- run formatter plugins via registry

## Testing
- `pytest tests/test_dialect_strictness.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689ad76a6c548326889fb584e0f2bde9