### PR TITLE
feat: add spacing and casing plugin

### DIFF
--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -60,6 +60,29 @@ def format(sql, encoding=None, **options):
     stack = formatter.build_filter_stack(stack, options)
     stack.postprocess.append(filters.SerializerUnicode())
     result = ''.join(stack.run(sql, encoding))
+
+    # Run formatter plugins if needed. Plugins are loaded lazily so the
+    # registry stays lightweight when no plugin options are supplied.
+    run_plugin = False
+    if options.get('spacing'):
+        run_plugin = True
+    elif options.get('keywords', {}).get('reserved_only'):
+        run_plugin = True
+    elif options.get('identifiers', {}).get('quote_style'):
+        run_plugin = True
+    elif options.get('identifiers', {}).get('keep_quoted_case') is False:
+        run_plugin = True
+
+    if run_plugin:
+        from sqlparse import plugins as _plugins
+        try:
+            __import__('sqlparse.plugins.spacing_casing')
+        except Exception:
+            _plugins = None
+        if _plugins is not None:
+            plugin_cls = _plugins.get_plugin('spacing_casing')
+            if plugin_cls is not None:
+                result = plugin_cls().format(result, options)
     if newline_at_eof is True:
         if not result.endswith('\n'):
             result += '\n'

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -174,7 +174,8 @@ def build_filter_stack(stack, options):
       options: Dictionary with options validated by validate_options.
     """
     # Token filter
-    if options.get('keyword_case'):
+    kw_opts = options.get('keywords', {})
+    if options.get('keyword_case') and not kw_opts.get('reserved_only'):
         stack.preprocess.append(
             filters.KeywordCaseFilter(options['keyword_case']))
 

--- a/sqlparse/plugins/spacing_casing.py
+++ b/sqlparse/plugins/spacing_casing.py
@@ -1,0 +1,54 @@
+import re
+
+from sqlparse import keywords
+from sqlparse import plugins
+
+
+class SpacingCasing(object):
+    """Formatter plugin providing spacing and casing options."""
+
+    RESERVED = set(k.upper() for k in keywords.KEYWORDS_COMMON.keys())
+
+    def format(self, text, options):
+        spacing = options.get('spacing') or {}
+        if spacing.get('compact_bool_not'):
+            text = re.sub(r'\bNOT\s+\(', 'NOT(', text, flags=re.IGNORECASE)
+
+        kw_opts = options.get('keywords') or {}
+        case = options.get('keyword_case')
+        if case and kw_opts.get('reserved_only'):
+            pattern = r'\b(' + '|'.join(self.RESERVED) + r')\b'
+            def repl(match):
+                word = match.group(0)
+                return getattr(str, case)(word)
+            text = re.sub(pattern, repl, text, flags=re.IGNORECASE)
+
+        ident_opts = options.get('identifiers') or {}
+        quote_style = ident_opts.get('quote_style')
+        keep_case = ident_opts.get('keep_quoted_case', True)
+        id_case = options.get('identifier_case')
+
+        if quote_style == 'backtick':
+            left = right = '`'
+        elif quote_style == 'bracket':
+            left, right = '[', ']'
+        else:
+            left = right = '"'
+
+        if quote_style:
+            def repl_quotes(match):
+                inner = match.group(1) or match.group(2) or match.group(3)
+                if not keep_case and id_case:
+                    inner = getattr(str, id_case)(inner)
+                return left + inner + right
+            text = re.sub(r'"([^"]*)"|`([^`]*)`|\[([^\]]*)\]', repl_quotes, text)
+        elif id_case and not keep_case:
+            def repl_case(match):
+                inner = getattr(str, id_case)(match.group(1))
+                return '"' + inner + '"'
+            text = re.sub(r'"([^"]*)"', repl_case, text)
+
+        return text
+
+
+plugins.register_plugin('spacing_casing', SpacingCasing)

--- a/tests/test_spacing_casing_plugin.py
+++ b/tests/test_spacing_casing_plugin.py
@@ -1,0 +1,23 @@
+import sqlparse
+
+
+def test_compact_bool_not():
+    sql = 'select not (a) from foo'
+    formatted = sqlparse.format(sql, spacing={'compact_bool_not': True}, keyword_case='upper')
+    assert formatted == 'SELECT NOT(a) FROM foo'
+
+
+def test_reserved_only_keyword_case():
+    sql = 'select * from table t'
+    formatted = sqlparse.format(sql, keyword_case='upper', keywords={'reserved_only': True})
+    assert formatted == 'SELECT * FROM table t'
+
+
+def test_identifier_quote_and_case():
+    sql = 'select "MixCase" from foo'
+    formatted = sqlparse.format(
+        sql,
+        identifier_case='lower',
+        identifiers={'quote_style': 'backtick', 'keep_quoted_case': False},
+    )
+    assert formatted == 'select `mixcase` from foo'


### PR DESCRIPTION
## Summary
- add spacing/casing plugin for compact NOT spacing, reserved keyword casing, and identifier quote controls
- integrate plugin into formatting pipeline
- cover new options with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ad77186ec8326a900ff849258bd74