### PR TITLE
feat: add join formatting plugin

### DIFF
--- a/doc/Configuration-Options-Thus-Far.md
+++ b/doc/Configuration-Options-Thus-Far.md
@@ -52,9 +52,9 @@
 - blank_lines.before_block: not implemented
 
 ## joins
-- join_on_new_line: not implemented
-- align_on_under_join: not implemented
-- prefer_explicit: not implemented
+- join_on_new_line: implemented
+- align_on_under_join: implemented
+- prefer_explicit: implemented
 
 ## predicates
 - layout: not implemented

--- a/sqlparse/plugins/joins.py
+++ b/sqlparse/plugins/joins.py
@@ -1,0 +1,68 @@
+import re
+import warnings
+
+import sqlparse
+from sqlparse import plugins
+
+
+class JoinPlugin(object):
+    """Formatter plugin implementing join configuration options."""
+
+    def format(self, stream, options):
+        """Format *stream* according to join options.
+
+        *stream* may be a SQL string. *options* is expected to contain a
+        ``joins`` dictionary with the keys ``join_on_new_line``,
+        ``align_on_under_join`` and ``prefer_explicit``.
+        """
+        if stream is None:
+            return stream
+
+        text = stream
+        join_opts = options.get('joins') or {}
+        join_on_new_line = bool(join_opts.get('join_on_new_line'))
+        align_on_under_join = bool(join_opts.get('align_on_under_join'))
+        prefer_explicit = bool(join_opts.get('prefer_explicit'))
+
+        if prefer_explicit:
+            if re.search(r'\bfrom\b[^;]*,[^;]*', text, re.I):
+                warnings.warn('comma join detected', UserWarning)
+
+        formatted = sqlparse.format(text, reindent=True)
+        lines = formatted.splitlines()
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.lstrip()
+            lower = stripped.lower()
+            if re.search(r'\bjoin\b', lower):
+                join_indent = len(line) - len(stripped)
+                on_match = re.search(r'\bON\b', line, re.I)
+                if on_match:
+                    if join_on_new_line:
+                        join_part = line[:on_match.start()].rstrip()
+                        on_part = line[on_match.start():].lstrip()
+                        indent = join_indent if align_on_under_join else join_indent + 2
+                        lines[i] = join_part
+                        lines.insert(i + 1, ' ' * indent + on_part)
+                        i += 2
+                        continue
+                else:
+                    if not join_on_new_line and i > 0:
+                        prev = lines[i - 1].rstrip()
+                        lines[i - 1] = prev + ' ' + stripped
+                        lines.pop(i)
+                        if i < len(lines) and lines[i].lstrip().lower().startswith('on '):
+                            if align_on_under_join:
+                                join_pos = lines[i - 1].lower().find('join')
+                                lines[i] = ' ' * join_pos + lines[i].lstrip()
+                        continue
+                if align_on_under_join and i + 1 < len(lines):
+                    next_line = lines[i + 1]
+                    if next_line.lstrip().lower().startswith('on '):
+                        lines[i + 1] = ' ' * (join_indent if align_on_under_join else join_indent + 2) + next_line.lstrip()
+            i += 1
+        return '\n'.join(lines)
+
+
+plugins.register_plugin('joins', JoinPlugin)

--- a/tests/test_plugin_joins.py
+++ b/tests/test_plugin_joins.py
@@ -1,0 +1,47 @@
+import warnings
+
+import sqlparse
+import warnings
+
+from sqlparse import plugins
+import sqlparse.plugins.joins  # ensure registration
+
+
+def run_plugin(sql, opts):
+    cls = plugins.get_plugin('joins')
+    return cls().format(sql, {'joins': opts})
+
+
+def test_join_alignment():
+    sql = 'select * from a join b on a.id = b.id'
+    formatted = run_plugin(sql, {
+        'join_on_new_line': True,
+        'align_on_under_join': True,
+    })
+    assert formatted == '\n'.join([
+        'select *',
+        'from a',
+        'join b',
+        'on a.id = b.id',
+    ])
+
+
+def test_join_same_line():
+    sql = 'select * from a join b on a.id = b.id'
+    formatted = run_plugin(sql, {
+        'join_on_new_line': False,
+    })
+    assert formatted == '\n'.join([
+        'select *',
+        'from a',
+        'join b on a.id = b.id',
+    ])
+
+
+def test_prefer_explicit_warns():
+    sql = 'select * from a, b'
+    cls = plugins.get_plugin('joins')
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        cls().format(sql, {'joins': {'prefer_explicit': True}})
+        assert w


### PR DESCRIPTION
## Summary
- add JoinPlugin to handle `join_on_new_line`, `align_on_under_join`, and `prefer_explicit`
- document join configuration options as implemented

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ad7aa07508326987f0a46f7654c0e