### PR TITLE
Add clause clause formatting plugin

### DIFF
--- a/doc/Configuration-Options-Thus-Far.md
+++ b/doc/Configuration-Options-Thus-Far.md
@@ -36,20 +36,20 @@
 - wrap_after: not implemented
 
 ## clauses
-- break.select: not implemented
-- break.from: not implemented
-- break.where: not implemented
-- break.group_by: not implemented
-- break.having: not implemented
-- break.order_by: not implemented
-- break.window: not implemented
-- break.join: not implemented
-- break.on: not implemented
-- break.with: not implemented
-- break.values: not implemented
-- blank_lines.before_with: not implemented
-- blank_lines.before_create: not implemented
-- blank_lines.before_block: not implemented
+- break.select: implemented
+- break.from: implemented
+- break.where: implemented
+- break.group_by: implemented
+- break.having: implemented
+- break.order_by: implemented
+- break.window: implemented
+- break.join: implemented
+- break.on: implemented
+- break.with: implemented
+- break.values: implemented
+- blank_lines.before_with: implemented
+- blank_lines.before_create: implemented
+- blank_lines.before_block: implemented
 
 ## joins
 - join_on_new_line: not implemented

--- a/sqlparse/plugins/clauses.py
+++ b/sqlparse/plugins/clauses.py
@@ -1,0 +1,64 @@
+from sqlparse import plugins
+
+
+class Clauses(object):
+    """Formatter plugin to control clause breaks and blank lines."""
+
+    CLAUSE_KEYS = (
+        'select', 'from', 'where', 'group_by', 'having', 'order_by',
+        'window', 'join', 'on', 'with', 'values'
+    )
+
+    BLANK_KEYS = (
+        'before_with', 'before_create', 'before_block'
+    )
+
+    def format(self, stream, options):
+        """Format *stream* according to clause options in *options*."""
+        text = stream
+        if isinstance(stream, (list, tuple)):
+            text = ''.join(stream)
+
+        opts = options.get('clauses') or {}
+        breaks = opts.get('break') or {}
+        blanks = opts.get('blank_lines') or {}
+
+        for key in self.CLAUSE_KEYS:
+            if breaks.get(key):
+                keyword = self._clause_keyword(key)
+                text = self._break_before(text, keyword)
+
+        for key in self.BLANK_KEYS:
+            count = blanks.get(key)
+            if count:
+                keyword = self._blank_keyword(key)
+                text = self._blank_before(text, keyword, count)
+
+        return text
+
+    def _clause_keyword(self, key):
+        return key.replace('_', ' ').upper()
+
+    def _break_before(self, text, keyword):
+        return text.replace(' ' + keyword, '\n' + keyword)
+
+    def _blank_keyword(self, key):
+        if key == 'before_with':
+            return 'WITH'
+        if key == 'before_create':
+            return 'CREATE'
+        if key == 'before_block':
+            return 'BEGIN'
+        return key.upper()
+
+    def _blank_before(self, text, keyword, count):
+        try:
+            count = int(count)
+        except Exception:
+            return text
+        if count < 1:
+            return text
+        seq = '\n' * (count + 1) + keyword
+        return text.replace('\n' + keyword, seq)
+
+plugins.register_plugin('clauses', Clauses)

--- a/tests/test_clauses_plugin.py
+++ b/tests/test_clauses_plugin.py
@@ -1,0 +1,20 @@
+import sqlparse.plugins.clauses  # noqa: F401
+from sqlparse import plugins
+
+
+def test_clause_breaks():
+    cls = plugins.get_plugin('clauses')
+    plugin = cls()
+    sql = 'SELECT a FROM t WHERE b=1'
+    opts = {'clauses': {'break': {'from': True, 'where': True}}}
+    formatted = plugin.format(sql, opts)
+    assert formatted == 'SELECT a\nFROM t\nWHERE b=1'
+
+
+def test_blank_lines_before_with():
+    cls = plugins.get_plugin('clauses')
+    plugin = cls()
+    sql = 'SELECT 1;\nWITH cte AS (SELECT 1) SELECT * FROM t'
+    opts = {'clauses': {'blank_lines': {'before_with': 1}}}
+    formatted = plugin.format(sql, opts)
+    assert formatted == 'SELECT 1;\n\nWITH cte AS (SELECT 1) SELECT * FROM t'


### PR DESCRIPTION
## Summary
- add clauses plugin to break major clauses and insert blank lines
- document clause break and blank-line options
- test clause formatting plugin

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ad78ce8d88326a26324f004c7459e