### PR TITLE
Implement predicate layout plugin

### DIFF
--- a/doc/Configuration-Options-Thus-Far.md
+++ b/doc/Configuration-Options-Thus-Far.md
@@ -57,7 +57,7 @@
 - prefer_explicit: not implemented
 
 ## predicates
-- layout: not implemented
+- layout: implemented
 
 ## case_expr
 - indent_when_then: not implemented

--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -15,10 +15,12 @@ from sqlparse import tokens
 from sqlparse import filters
 from sqlparse import formatter
 from sqlparse import config
+from sqlparse import plugins
 
 
 __version__ = '0.5.3'
-__all__ = ['engine', 'filters', 'formatter', 'sql', 'tokens', 'cli', 'config']
+__all__ = ['engine', 'filters', 'formatter', 'sql', 'tokens', 'cli', 'config',
+           'plugins']
 
 
 def parse(sql, encoding=None, dialect=None):
@@ -60,6 +62,20 @@ def format(sql, encoding=None, **options):
     stack = formatter.build_filter_stack(stack, options)
     stack.postprocess.append(filters.SerializerUnicode())
     result = ''.join(stack.run(sql, encoding))
+
+    for key in options:
+        if plugins.get_plugin(key) is None:
+            try:
+                __import__('sqlparse.plugins.{0}'.format(key), fromlist=['_'])
+            except Exception:
+                continue
+
+    for name in plugins.available_plugins():
+        if name in options:
+            plugin_cls = plugins.get_plugin(name)
+            if plugin_cls is not None:
+                plugin = plugin_cls()
+                result = plugin.format(result, options)
     if newline_at_eof is True:
         if not result.endswith('\n'):
             result += '\n'

--- a/sqlparse/plugins/__init__.py
+++ b/sqlparse/plugins/__init__.py
@@ -9,12 +9,22 @@ shared state.
 _registry = {}
 
 
-def register_plugin(name, plugin_cls):
+def register_plugin(name, plugin_cls=None):
     """Register *plugin_cls* under *name*.
 
+    Can be used as ``register_plugin('name', cls)`` or as a decorator::
+
+        @register_plugin('name')
+        class MyPlugin(object):
+            ...
+
     If a plugin with *name* already exists it will be replaced.
-    The function returns the class to allow usage as a decorator.
     """
+    if plugin_cls is None:
+        def decorator(cls):
+            _registry[name] = cls
+            return cls
+        return decorator
     _registry[name] = plugin_cls
     return plugin_cls
 

--- a/sqlparse/plugins/predicates.py
+++ b/sqlparse/plugins/predicates.py
@@ -1,0 +1,52 @@
+"""Predicate layout plugin."""
+
+import re
+
+from sqlparse import plugins
+
+
+@plugins.register_plugin('predicates')
+class PredicateLayout(object):
+    """Handle predicate layout options.
+
+    Supported options::
+
+        predicates.layout: "compact", "one_per_line", or "heuristic"
+    """
+
+    def format(self, stream, options):
+        opts = options.get('predicates')
+        if not isinstance(opts, dict):
+            return stream
+
+        layout = opts.get('layout')
+        if layout not in ('compact', 'one_per_line', 'heuristic'):
+            return stream
+        if layout == 'compact':
+            return stream
+
+        indent_width = options.get('indent_width', 2)
+        indent = ' ' * indent_width
+
+        def apply_one_per_line(txt):
+            txt = re.sub(r'(WHERE)\s+', 'WHERE\n' + indent, txt,
+                         flags=re.IGNORECASE)
+            txt = re.sub(r'\s+(AND|OR)\s+',
+                         '\n' + indent + r'\1 ', txt,
+                         flags=re.IGNORECASE)
+            return txt
+
+        text = stream
+        if layout == 'one_per_line':
+            return apply_one_per_line(text)
+
+        # heuristic
+        match = re.search(r'\bWHERE\b', text, flags=re.IGNORECASE)
+        if match is None:
+            return stream
+        after = text[match.end():]
+        bool_ops = re.findall(r'\b(AND|OR)\b', after, flags=re.IGNORECASE)
+        if len(bool_ops) <= 1 and len(after.strip()) <= 40:
+            return stream
+        return apply_one_per_line(text)
+

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -1,0 +1,34 @@
+import sqlparse
+
+
+class TestPredicateLayout:
+    def test_compact(self):
+        sql = 'SELECT * FROM foo WHERE a=1 AND b=2 OR c=3'
+        res = sqlparse.format(sql, predicates={'layout': 'compact'})
+        assert res == sql
+
+    def test_one_per_line(self):
+        sql = 'SELECT * FROM foo WHERE a=1 AND b=2 OR c=3'
+        res = sqlparse.format(sql, predicates={'layout': 'one_per_line'})
+        assert res == (
+            'SELECT * FROM foo WHERE\n'
+            '  a=1\n'
+            '  AND b=2\n'
+            '  OR c=3'
+        )
+
+    def test_heuristic(self):
+        sql = 'SELECT * FROM foo WHERE a=1 AND b=2 OR c=3'
+        res = sqlparse.format(sql, predicates={'layout': 'heuristic'})
+        assert res == (
+            'SELECT * FROM foo WHERE\n'
+            '  a=1\n'
+            '  AND b=2\n'
+            '  OR c=3'
+        )
+
+    def test_heuristic_no_break(self):
+        sql = 'SELECT * FROM foo WHERE a=1 AND b=2'
+        res = sqlparse.format(sql, predicates={'layout': 'heuristic'})
+        assert res == sql
+


### PR DESCRIPTION
## Summary
- add `predicates` formatter plugin for configurable boolean chain layout
- hook plugin registry into `format` and support decorator-based plugin registration
- document `predicates.layout` option and test formatting modes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ad7d0cd6c8326867bea6c3481cc98