### PR TITLE
Add CASE expression formatting plugin

### DIFF
--- a/doc/Configuration-Options-Thus-Far.md
+++ b/doc/Configuration-Options-Thus-Far.md
@@ -60,9 +60,9 @@
 - layout: not implemented
 
 ## case_expr
-- indent_when_then: not implemented
-- align_then: not implemented
-- end_align_with_case: not implemented
+- indent_when_then: implemented
+- align_then: implemented
+- end_align_with_case: implemented
 
 ## cte
 - one_per_line: not implemented

--- a/sqlparse/plugins/case_expr.py
+++ b/sqlparse/plugins/case_expr.py
@@ -1,0 +1,103 @@
+from __future__ import unicode_literals
+
+"""CASE expression formatting plugin."""
+
+from sqlparse import parse
+from sqlparse.sql import Case
+from sqlparse import plugins
+from sqlparse import tokens as T
+
+try:
+    unicode
+except NameError:  # pragma: no cover - Py3
+    unicode = str
+
+try:
+    basestring
+except NameError:  # pragma: no cover - Py3
+    basestring = str
+
+
+class CaseExpressionFormatter(object):
+    """Format CASE expressions according to configuration options.
+
+    Supported options inside the ``case_expr`` section:
+
+    ``indent_when_then`` -- indent WHEN/THEN/ELSE lines.
+    ``align_then`` -- align THEN clauses across WHEN conditions.
+    ``end_align_with_case`` -- align END with CASE keyword.
+    """
+
+    def format(self, stream, options):
+        # Allow passing either the whole options dict or the case_expr section.
+        case_opts = options.get('case_expr') if isinstance(options, dict) else None
+        if case_opts is None:
+            case_opts = options
+        indent_width = case_opts.get('indent_width') or options.get('indent_width') or 2
+        indent_char = case_opts.get('indent_char') or options.get('indent_char') or ' '
+        indent = indent_char * indent_width
+
+        indent_when_then = case_opts.get('indent_when_then')
+        align_then = case_opts.get('align_then')
+        end_align_with_case = case_opts.get('end_align_with_case')
+
+        if isinstance(stream, basestring):
+            text = stream
+        else:
+            text = ''.join(stream)
+
+        statements = parse(text)
+        for stmt in statements:
+            for token in stmt.tokens:
+                if isinstance(token, Case):
+                    formatted = self._format_case(token, indent_when_then, align_then,
+                                                  end_align_with_case, indent)
+                    text = text.replace(str(token), formatted, 1)
+        return text
+
+    def _format_case(self, case, indent_when_then, align_then, end_align_with_case, indent):
+        cases = case.get_cases(skip_ws=True)
+        parts = []
+        when_clauses = []
+        else_clause = None
+        max_when = 0
+        for cond, val in cases:
+            if cond is None:
+                if val and val[0].match(T.Keyword, 'ELSE'):
+                    val = val[1:]
+                else_clause = ''.join([unicode(t) for t in val]).strip()
+            else:
+                if cond and cond[0].match(T.Keyword, 'WHEN'):
+                    cond = cond[1:]
+                if val and val[0].match(T.Keyword, 'THEN'):
+                    val = val[1:]
+                cond_str = ''.join([unicode(t) for t in cond]).strip()
+                then_str = ''.join([unicode(t) for t in val]).strip()
+                when_clauses.append((cond_str, then_str))
+                if len(cond_str) > max_when:
+                    max_when = len(cond_str)
+
+        parts.append('CASE')
+        for cond_str, then_str in when_clauses:
+            line = 'WHEN ' + cond_str
+            if align_then:
+                pad = max_when - len(cond_str)
+                if pad > 0:
+                    line += ' ' * pad
+            line += ' THEN ' + then_str
+            if indent_when_then:
+                line = indent + line
+            parts.append(line)
+        if else_clause is not None:
+            line = 'ELSE ' + else_clause
+            if indent_when_then:
+                line = indent + line
+            parts.append(line)
+        end_line = 'END'
+        if indent_when_then and not end_align_with_case:
+            end_line = indent + end_line
+        parts.append(end_line)
+        return '\n'.join(parts)
+
+
+plugins.register_plugin('case_expr', CaseExpressionFormatter)

--- a/tests/test_case_expr_plugin.py
+++ b/tests/test_case_expr_plugin.py
@@ -1,0 +1,36 @@
+import sqlparse.plugins.case_expr  # ensure registration
+from sqlparse import plugins
+
+
+def test_case_expr_formatting_align_then():
+    formatter = plugins.get_plugin('case_expr')()
+    sql = 'CASE WHEN foo=1 THEN x WHEN foo=20 THEN y ELSE z END'
+    opts = {
+        'case_expr': {
+            'indent_when_then': True,
+            'align_then': True,
+            'end_align_with_case': True,
+        },
+        'indent_width': 2,
+        'indent_char': ' '
+    }
+    formatted = formatter.format(sql, opts)
+    expected = 'CASE\n  WHEN foo=1  THEN x\n  WHEN foo=20 THEN y\n  ELSE z\nEND'
+    assert formatted == expected
+
+
+def test_case_expr_end_indented():
+    formatter = plugins.get_plugin('case_expr')()
+    sql = 'CASE WHEN foo=1 THEN x END'
+    opts = {
+        'case_expr': {
+            'indent_when_then': True,
+            'align_then': False,
+            'end_align_with_case': False,
+        },
+        'indent_width': 2,
+        'indent_char': ' '
+    }
+    formatted = formatter.format(sql, opts)
+    expected = 'CASE\n  WHEN foo=1 THEN x\n  END'
+    assert formatted == expected


### PR DESCRIPTION
## Summary
- add `case_expr` plugin to format CASE statements with indentation and alignment controls
- document CASE expression options as implemented
- test CASE plugin formatting for alignment and END placement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ad7e9ff148326a28230aeec21bfaf