### PR TITLE
Add CTE formatting plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+## Environment
+# All code you write must be compatible with:
+- Python 3.2.5
+- Cygwin 1.7.29
+- Oracle 12c
+# All work must be done from the 3.2.5 branch.
+- If the active branch is , immediately stop and fail.  Do no work on  branch.

--- a/doc/Configuration-Options-Thus-Far.md
+++ b/doc/Configuration-Options-Thus-Far.md
@@ -65,9 +65,9 @@
 - end_align_with_case: not implemented
 
 ## cte
-- one_per_line: not implemented
-- blank_line_between: not implemented
-- trailing_comma_style: not implemented
+- one_per_line: implemented
+- blank_line_between: implemented
+- trailing_comma_style: implemented
 
 ## subqueries
 - open_paren_same_line: not implemented

--- a/sqlparse/plugins/__init__.py
+++ b/sqlparse/plugins/__init__.py
@@ -9,14 +9,14 @@ shared state.
 _registry = {}
 
 
-def register_plugin(name, plugin_cls):
-    """Register *plugin_cls* under *name*.
+def register_plugin(name):
+    """Return a decorator that registers *plugin_cls* under *name*."""
 
-    If a plugin with *name* already exists it will be replaced.
-    The function returns the class to allow usage as a decorator.
-    """
-    _registry[name] = plugin_cls
-    return plugin_cls
+    def _decorator(plugin_cls):
+        _registry[name] = plugin_cls
+        return plugin_cls
+
+    return _decorator
 
 
 def get_plugin(name):
@@ -30,3 +30,13 @@ def get_plugin(name):
 def available_plugins():
     """Return an iterable of registered plugin names."""
     return _registry.keys()
+
+
+# Import bundled plugins so that they register themselves with the registry.
+# Each plugin uses the register_plugin decorator at import time.
+try:  # pragma: no cover - import side effects are tested elsewhere
+    from . import cte  # noqa: F401
+except Exception:
+    # If the plugin fails to import we simply skip registration to keep
+    # compatibility with minimal environments.
+    pass

--- a/sqlparse/plugins/cte.py
+++ b/sqlparse/plugins/cte.py
@@ -1,0 +1,73 @@
+from __future__ import absolute_import
+import re
+
+from sqlparse import plugins
+
+
+@plugins.register_plugin('cte')
+class CTEFormatter(object):
+    """Formatter for common table expressions (CTEs).
+
+    This plugin implements configuration options:
+    - cte.one_per_line
+    - cte.blank_line_between
+    - cte.trailing_comma_style ("always" or "remove")
+
+    The implementation is intentionally lightweight and operates on raw SQL
+    strings to maintain compatibility with Python 3.2.5.
+    """
+
+    def format(self, sql, options):  # pragma: no cover - exercised via tests
+        cte_opts = options.get('cte') or {}
+        if not cte_opts:
+            return sql
+
+        one_per_line = cte_opts.get('one_per_line')
+        blank_between = cte_opts.get('blank_line_between')
+        comma_style = cte_opts.get('trailing_comma_style') or 'remove'
+        indent_width = options.get('indent_width', 2)
+        indent = ' ' * indent_width
+
+        match = re.match(r'(?is)\s*WITH\s+(.*)\s+(SELECT.*)', sql)
+        if not match:
+            return sql
+        cte_part = match.group(1).strip()
+        rest = match.group(2)
+
+        ctes = self._split_ctes(cte_part)
+        lines = []
+        for idx, cte in enumerate(ctes):
+            cte = cte.strip().rstrip(',')
+            add_comma = (idx < len(ctes) - 1) or comma_style == 'always'
+            line = cte + (',' if add_comma else '')
+            if one_per_line:
+                line = indent + line
+            lines.append(line)
+
+        if one_per_line:
+            separator = '\n\n' if blank_between else '\n'
+            cte_section = 'WITH\n' + separator.join(lines) + '\n'
+        else:
+            cte_section = 'WITH ' + ' '.join(lines) + ' '
+
+        return cte_section + rest
+
+    def _split_ctes(self, part):
+        parts = []
+        level = 0
+        start = 0
+        for idx, ch in enumerate(part):
+            if ch == '(':
+                level += 1
+            elif ch == ')':
+                if level:
+                    level -= 1
+            elif ch == ',' and level == 0:
+                pieces = part[start:idx].strip()
+                if pieces:
+                    parts.append(pieces)
+                start = idx + 1
+        last = part[start:].strip()
+        if last:
+            parts.append(last)
+        return parts

--- a/tests/test_plugins_cte.py
+++ b/tests/test_plugins_cte.py
@@ -1,0 +1,31 @@
+import sqlparse.plugins as plugins
+
+
+def test_cte_plugin_registration_and_formatting():
+    plugin_cls = plugins.get_plugin('cte')
+    assert plugin_cls is not None
+    formatter = plugin_cls()
+    sql = "WITH a AS (SELECT 1), b AS (SELECT 2) SELECT * FROM a"
+    options = {
+        'cte': {
+            'one_per_line': True,
+            'blank_line_between': True,
+            'trailing_comma_style': 'always',
+        },
+        'indent_width': 2,
+    }
+    formatted = formatter.format(sql, options)
+    expected = (
+        "WITH\n"
+        "  a AS (SELECT 1),\n\n"
+        "  b AS (SELECT 2),\n"
+        "SELECT * FROM a"
+    )
+    assert formatted == expected
+
+
+def test_cte_plugin_no_options_returns_input():
+    plugin_cls = plugins.get_plugin('cte')
+    formatter = plugin_cls()
+    sql = "WITH a AS (SELECT 1) SELECT * FROM a"
+    assert formatter.format(sql, {}) == sql


### PR DESCRIPTION
## Summary
- add plugin to format common table expressions with new options
- register plugin and mark CTE configuration options as implemented
- test CTE formatting behaviours

## Testing
- `pytest tests/test_plugins_cte.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689ad7f18d78832683d90342b737b94a