### PR TITLE
Implement subquery formatting plugin (Phase 9)

### DIFF
--- a/doc/Configuration-Options-Thus-Far.md
+++ b/doc/Configuration-Options-Thus-Far.md
@@ -70,10 +70,10 @@
 - trailing_comma_style: not implemented
 
 ## subqueries
-- open_paren_same_line: not implemented
-- body_indent: not implemented
-- close_paren_align_with_open: not implemented
-- prefer_keyword_on_newline: not implemented
+- open_paren_same_line: implemented
+- body_indent: implemented
+- close_paren_align_with_open: implemented
+- prefer_keyword_on_newline: implemented
 
 ## blocks
 - begin_same_line: not implemented

--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -15,10 +15,11 @@ from sqlparse import tokens
 from sqlparse import filters
 from sqlparse import formatter
 from sqlparse import config
+from sqlparse import plugins
 
 
 __version__ = '0.5.3'
-__all__ = ['engine', 'filters', 'formatter', 'sql', 'tokens', 'cli', 'config']
+__all__ = ['engine', 'filters', 'formatter', 'sql', 'tokens', 'cli', 'config', 'plugins']
 
 
 def parse(sql, encoding=None, dialect=None):
@@ -60,6 +61,11 @@ def format(sql, encoding=None, **options):
     stack = formatter.build_filter_stack(stack, options)
     stack.postprocess.append(filters.SerializerUnicode())
     result = ''.join(stack.run(sql, encoding))
+    for name, section in options.items():
+        plugin_cls = plugins.get_plugin(name)
+        if plugin_cls is not None and isinstance(section, dict):
+            plugin = plugin_cls()
+            result = plugin.format(result, section)
     if newline_at_eof is True:
         if not result.endswith('\n'):
             result += '\n'

--- a/sqlparse/plugins/__init__.py
+++ b/sqlparse/plugins/__init__.py
@@ -24,7 +24,14 @@ def get_plugin(name):
 
     Parameters are intentionally simple for compatibility with Python 3.2.5.
     """
-    return _registry.get(name)
+    cls = _registry.get(name)
+    if cls is None:
+        try:
+            __import__('sqlparse.plugins.{0}'.format(name))
+        except Exception:
+            return None
+        cls = _registry.get(name)
+    return cls
 
 
 def available_plugins():

--- a/sqlparse/plugins/subqueries.py
+++ b/sqlparse/plugins/subqueries.py
@@ -1,0 +1,87 @@
+from __future__ import absolute_import
+
+import sqlparse
+from sqlparse import plugins
+
+
+class Subqueries(object):
+    """Very small formatter for subquery placement."""
+
+    def format(self, sql, options):
+        open_same = options.get('open_paren_same_line', True)
+        body_indent = int(options.get('body_indent', 2))
+        close_align = options.get('close_paren_align_with_open', True)
+        prefer_kw_newline = options.get('prefer_keyword_on_newline', False)
+
+        def find_subqueries(text):
+            positions = []
+            lower = text.lower()
+            start = 0
+            while True:
+                idx = lower.find('(select', start)
+                if idx == -1:
+                    break
+                depth = 1
+                i = idx + 1
+                length = len(text)
+                while i < length:
+                    ch = text[i]
+                    if ch == '(':
+                        depth += 1
+                    elif ch == ')':
+                        depth -= 1
+                        if depth == 0:
+                            positions.append((idx, i))
+                            break
+                    i += 1
+                start = i + 1
+            return positions
+
+        def calc_indent(text, pos):
+            before = text[:pos]
+            nl = before.rfind('\n')
+            if nl == -1:
+                return 0
+            line = before[nl + 1:]
+            stripped = line.lstrip(' ')
+            return len(line) - len(stripped)
+
+        positions = find_subqueries(sql)
+        for start, end in reversed(positions):
+            indent = calc_indent(sql, start)
+            inner = sql[start + 1:end]
+            formatted = sqlparse.format(inner.strip(), reindent=True,
+                                        indent_width=body_indent)
+            lines = [l.rstrip() for l in formatted.strip().splitlines()]
+            before = sql[:start]
+            after = sql[end + 1:]
+
+            if open_same:
+                before = before.rstrip() + ' '
+                open_part = '('
+            else:
+                before = before.rstrip()
+                open_part = '\n' + ' ' * indent + '('
+
+            if prefer_kw_newline:
+                inner_text = '\n'.join(' ' * (indent + body_indent) + line
+                                        for line in lines)
+                replacement = open_part + '\n' + inner_text
+            else:
+                first = lines[0] if lines else ''
+                rest = lines[1:] if len(lines) > 1 else []
+                rest_text = '\n'.join(' ' * (indent + body_indent) + line
+                                       for line in rest)
+                replacement = open_part + ' ' + first
+                if rest_text:
+                    replacement += '\n' + rest_text
+
+            close_indent = indent if close_align else indent + body_indent
+            replacement += '\n' + ' ' * close_indent + ')'
+
+            sql = before + replacement + after
+
+        return sql
+
+
+plugins.register_plugin('subqueries', Subqueries)

--- a/tests/test_subqueries_plugin.py
+++ b/tests/test_subqueries_plugin.py
@@ -1,0 +1,32 @@
+import sqlparse
+
+
+def test_subquery_newline_and_indent():
+    sql = 'SELECT * FROM (SELECT 1) x'
+    formatted = sqlparse.format(
+        sql,
+        reindent=True,
+        subqueries={
+            'open_paren_same_line': False,
+            'body_indent': 2,
+            'close_paren_align_with_open': True,
+            'prefer_keyword_on_newline': True,
+        },
+    )
+    assert formatted == 'SELECT *\nFROM\n  (\n    SELECT 1\n  ) x'
+
+
+def test_subquery_close_paren_indent():
+    sql = 'SELECT * FROM (SELECT 1) x'
+    formatted = sqlparse.format(
+        sql,
+        reindent=True,
+        subqueries={
+            'open_paren_same_line': True,
+            'body_indent': 2,
+            'close_paren_align_with_open': False,
+            'prefer_keyword_on_newline': True,
+        },
+    )
+    assert formatted == 'SELECT *\nFROM (\n    SELECT 1\n    ) x'
+


### PR DESCRIPTION
## Summary
- add configurable subquery formatter plugin
- integrate plugin registry with sqlparse.format
- support lazy plugin loading and document subquery options

## Testing
- `pytest tests/test_subqueries_plugin.py::test_subquery_newline_and_indent -q`
- `pytest tests/test_subqueries_plugin.py::test_subquery_close_paren_indent -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689ad7f9dd0883268b6788c5e1473006