### PR TITLE
Add CREATE TABLE formatting plugin

### DIFF
--- a/doc/Configuration-Options-Thus-Far.md
+++ b/doc/Configuration-Options-Thus-Far.md
@@ -87,9 +87,9 @@
 - align_assignment: not implemented
 
 ## create_table
-- align_columns: not implemented
-- comma_last: not implemented
-- one_column_per_line: not implemented
+- align_columns: implemented
+- comma_last: implemented
+- one_column_per_line: implemented
 
 ## comments
 - reflow_block_comments: not implemented

--- a/sqlparse/plugins/create_table.py
+++ b/sqlparse/plugins/create_table.py
@@ -1,0 +1,87 @@
+from sqlparse import plugins
+
+
+class CreateTablePlugin(object):
+    """Formatter plugin for CREATE TABLE statements.
+
+    Supports options from the ``create_table`` section:
+
+    - align_columns: Align column definitions.
+    - comma_last: Place commas at end of lines if True, else at start.
+    - one_column_per_line: Put each column definition on its own line.
+    """
+
+    def format(self, stream, options):
+        if isinstance(stream, str):
+            sql = stream
+        else:
+            sql = ''.join(stream)
+        opts = {}
+        if options:
+            opts = options.get('create_table') or {}
+        if 'CREATE TABLE' not in sql.upper():
+            return sql
+        try:
+            prefix, rest = sql.split('(', 1)
+            body, suffix = rest.rsplit(')', 1)
+        except ValueError:
+            return sql
+        columns = []
+        for part in body.split(','):
+            columns.append(part.strip())
+        align = bool(opts.get('align_columns'))
+        comma_last = True
+        if 'comma_last' in opts:
+            comma_last = bool(opts.get('comma_last'))
+        one_per_line = bool(opts.get('one_column_per_line'))
+        if align:
+            names = []
+            for col in columns:
+                parts = col.split(None, 1)
+                if parts:
+                    names.append(parts[0])
+            max_len = 0
+            for name in names:
+                if len(name) > max_len:
+                    max_len = len(name)
+            aligned = []
+            for col in columns:
+                parts = col.split(None, 1)
+                if len(parts) > 1:
+                    name, restcol = parts[0], parts[1]
+                    pad = ' ' * (max_len - len(name) + 1)
+                    aligned.append(name + pad + restcol)
+                else:
+                    aligned.append(col)
+            columns = aligned
+        if one_per_line:
+            lines = []
+            for idx, col in enumerate(columns):
+                if comma_last:
+                    line = col
+                    if idx != len(columns) - 1:
+                        line += ','
+                    lines.append(line)
+                else:
+                    if idx == 0:
+                        lines.append(col)
+                    else:
+                        lines.append(', ' + col)
+            body = '\n  '.join(lines)
+            formatted = prefix.rstrip() + ' (\n  ' + body + '\n)' + suffix
+        else:
+            if comma_last:
+                body = ', '.join(columns)
+            else:
+                if columns:
+                    body = columns[0]
+                    for col in columns[1:]:
+                        body += ' , ' + col
+                else:
+                    body = ''
+            formatted = prefix.rstrip() + ' (' + body + ')' + suffix
+        return formatted
+
+
+# Register plugin at import time
+plugins.register_plugin('create_table', CreateTablePlugin)

--- a/tests/test_create_table_plugin.py
+++ b/tests/test_create_table_plugin.py
@@ -1,0 +1,36 @@
+import sqlparse
+from sqlparse import plugins
+
+
+def get_plugin():
+    # ensure module import registers plugin
+    import sqlparse.plugins.create_table  # noqa: F401
+    cls = plugins.get_plugin('create_table')
+    return cls()
+
+
+def test_create_table_one_column_per_line():
+    plugin = get_plugin()
+    sql = 'CREATE TABLE foo(id INT, name TEXT);'
+    opts = {'create_table': {'one_column_per_line': True}}
+    result = plugin.format(sql, opts)
+    expected = 'CREATE TABLE foo (\n  id INT,\n  name TEXT\n);'
+    assert result == expected
+
+
+def test_create_table_comma_first():
+    plugin = get_plugin()
+    sql = 'CREATE TABLE foo(id INT, name TEXT);'
+    opts = {'create_table': {'one_column_per_line': True, 'comma_last': False}}
+    result = plugin.format(sql, opts)
+    expected = 'CREATE TABLE foo (\n  id INT\n  , name TEXT\n);'
+    assert result == expected
+
+
+def test_create_table_align_columns():
+    plugin = get_plugin()
+    sql = 'CREATE TABLE foo(id INT, name TEXT);'
+    opts = {'create_table': {'one_column_per_line': True, 'align_columns': True}}
+    result = plugin.format(sql, opts)
+    expected = 'CREATE TABLE foo (\n  id   INT,\n  name TEXT\n);'
+    assert result == expected


### PR DESCRIPTION
## Summary
- add `CreateTablePlugin` to format CREATE TABLE statements
- mark `create_table` configuration options as implemented
- cover new plugin with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ad808c4a08326a663aa40205c33dc