### PR TITLE
Add comments formatter plugin

### DIFF
--- a/doc/Configuration-Options-Thus-Far.md
+++ b/doc/Configuration-Options-Thus-Far.md
@@ -92,10 +92,10 @@
 - one_column_per_line: not implemented
 
 ## comments
-- reflow_block_comments: not implemented
-- keep_trailing_line_comment_with_code: not implemented
-- pragma_freeze_directives: not implemented
-- preserve_comment_position: not implemented
+- reflow_block_comments: implemented
+- keep_trailing_line_comment_with_code: implemented
+- pragma_freeze_directives: implemented
+- preserve_comment_position: implemented
 
 ## penalties
 - break_after_select: not implemented

--- a/sqlparse/plugins/comments.py
+++ b/sqlparse/plugins/comments.py
@@ -1,0 +1,91 @@
+from __future__ import print_function
+import re
+
+from sqlparse import plugins
+
+
+class CommentFormatter(object):
+    """Formatter plugin to handle comment related options.
+
+    The formatter operates on plain SQL strings for simplicity. It supports
+    several options passed in the *options* dictionary under the ``comments``
+    key:
+
+    ``reflow_block_comments``
+        Collapse consecutive whitespace inside block comments.
+
+    ``keep_trailing_line_comment_with_code``
+        If ``False`` move trailing line comments onto their own line.
+
+    ``pragma_freeze_directives``
+        Honour ``-- sqlparse: off`` / ``-- sqlparse: on`` regions which are
+        left untouched by the formatter.
+
+    ``preserve_comment_position``
+        When ``True`` no positional changes to comments are made.
+    """
+
+    def format(self, sql, options):
+        opts = options or {}
+        if 'comments' in opts:
+            opts = opts.get('comments') or {}
+
+        reflow = bool(opts.get('reflow_block_comments'))
+        keep_trailing = opts.get('keep_trailing_line_comment_with_code', True)
+        freeze = bool(opts.get('pragma_freeze_directives'))
+        preserve = bool(opts.get('preserve_comment_position'))
+
+        if not sql:
+            return sql
+
+        def process_segment(segment):
+            if not segment:
+                return segment
+            if reflow:
+                def repl(match):
+                    content = match.group(1)
+                    if freeze and 'sqlparse: off' in content.lower():
+                        return match.group(0)
+                    content = ' '.join(content.split())
+                    return '/* {0} */'.format(content)
+                segment = re.sub(r'/\*(.*?)\*/', repl, segment, flags=re.S)
+            if not preserve and not keep_trailing:
+                def move(m):
+                    code = m.group(1).rstrip()
+                    comment = m.group(2).rstrip()
+                    if code:
+                        return code + '\n' + comment
+                    return m.group(0)
+                segment = re.sub(r'([^\n]*?)(--[^\n]*)', move, segment)
+            return segment
+
+        if freeze:
+            lines = sql.splitlines(True)
+            result = []
+            frozen = False
+            buffer = ''
+            for line in lines:
+                stripped = line.strip().lower()
+                if stripped == '-- sqlparse: off':
+                    result.append(process_segment(buffer))
+                    buffer = ''
+                    frozen = True
+                    result.append(line)
+                    continue
+                if stripped == '-- sqlparse: on':
+                    frozen = False
+                    result.append(line)
+                    continue
+                if frozen:
+                    result.append(line)
+                else:
+                    buffer += line
+            if buffer:
+                result.append(process_segment(buffer))
+            sql = ''.join(result)
+        else:
+            sql = process_segment(sql)
+        return sql
+
+
+plugins.register_plugin('comments', CommentFormatter)

--- a/tests/test_comments_plugin.py
+++ b/tests/test_comments_plugin.py
@@ -1,0 +1,55 @@
+from sqlparse.plugins import get_plugin
+import sqlparse.plugins.comments  # ensure plugin registration
+
+
+def _format(sql, **opts):
+    plugin_cls = get_plugin('comments')
+    plugin = plugin_cls()
+    return plugin.format(sql, {'comments': opts})
+
+
+def test_reflow_block_comments():
+    sql = 'SELECT 1; /*  foo   bar   baz  */'
+    res = _format(sql, reflow_block_comments=True)
+    assert res == 'SELECT 1; /* foo bar baz */'
+
+
+def test_move_trailing_line_comment():
+    sql = 'SELECT 1 -- comment'
+    res = _format(sql, keep_trailing_line_comment_with_code=False)
+    assert res == 'SELECT 1\n-- comment'
+
+
+def test_preserve_trailing_comment():
+    sql = 'SELECT 1 -- comment'
+    res = _format(
+        sql,
+        keep_trailing_line_comment_with_code=False,
+        preserve_comment_position=True,
+    )
+    assert res == 'SELECT 1 -- comment'
+
+
+def test_freeze_directives():
+    sql = (
+        'SELECT 1 -- keep\n'
+        '-- sqlparse: off\n'
+        'SELECT 2 -- frozen\n'
+        '-- sqlparse: on\n'
+        '/* foo   bar */'
+    )
+    res = _format(
+        sql,
+        pragma_freeze_directives=True,
+        keep_trailing_line_comment_with_code=False,
+        reflow_block_comments=True,
+    )
+    expected = (
+        'SELECT 1\n'
+        '-- keep\n'
+        '-- sqlparse: off\n'
+        'SELECT 2 -- frozen\n'
+        '-- sqlparse: on\n'
+        '/* foo bar */'
+    )
+    assert res == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,6 +101,9 @@ def test_load_clang_config_full_sections(tmpdir):
         'create_table:\n'
         '  align_columns: false\n'
         'comments:\n'
+        '  reflow_block_comments: true\n'
+        '  keep_trailing_line_comment_with_code: false\n'
+        '  pragma_freeze_directives: true\n'
         '  preserve_comment_position: true\n'
         'penalties:\n'
         '  over_column_limit: 500\n'
@@ -123,5 +126,8 @@ def test_load_clang_config_full_sections(tmpdir):
     assert opts['blocks']['begin_same_line'] is False
     assert opts['declarations']['one_per_line'] is True
     assert opts['create_table']['align_columns'] is False
+    assert opts['comments']['reflow_block_comments'] is True
+    assert opts['comments']['keep_trailing_line_comment_with_code'] is False
+    assert opts['comments']['pragma_freeze_directives'] is True
     assert opts['comments']['preserve_comment_position'] is True
     assert opts['penalties']['over_column_limit'] == 500


### PR DESCRIPTION
## Summary
- implement CommentFormatter plugin for block and line comment handling
- document and test new comment configuration options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ad80e42948326b6c2efa61020dcb9