### PR TITLE
Load and run configuration plugins

### DIFF
--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -20,6 +20,32 @@ from sqlparse import plugins
 __version__ = '0.5.3'
 __all__ = ['engine', 'filters', 'formatter', 'sql', 'tokens', 'cli', 'config', 'plugins']
 
+# Mapping from option section names to plugin registry names.
+_OPTION_TO_PLUGIN = {
+    'lists': 'lists',
+    'spacing': 'spacing_casing',
+    'keywords': 'spacing_casing',
+    'identifiers': 'spacing_casing',
+    'dialect_options': 'dialect_strictness',
+    'layout': 'dialect_strictness',
+    'clauses': 'clauses',
+    'joins': 'joins',
+    'predicates': 'predicates',
+    'case_expr': 'case_expr',
+    'cte': 'cte',
+    'subqueries': 'subqueries',
+    'blocks': 'blocks',
+    'declarations': 'blocks',
+    'create_table': 'create_table',
+    'comments': 'comments',
+    'penalties': 'penalties',
+}
+
+# Mapping from plugin registry names to module names when they differ.
+_PLUGIN_MODULES = {
+    'lists': 'list_controls',
+}
+
 
 def parse(sql, encoding=None, dialect=None):
     """Parse sql and return a list of statements.
@@ -69,15 +95,33 @@ def format(sql, encoding=None, **options):
     for name in list(options.keys()):
         section = options.get(name)
         if isinstance(section, dict):
-            if plugins.get_plugin(name) is None:
-                module = _PLUGIN_MODULES.get(name, name)
+            plugin_name = _OPTION_TO_PLUGIN.get(name)
+            if plugin_name is None:
+                continue
+            if plugins.get_plugin(plugin_name) is None:
+                module = _PLUGIN_MODULES.get(plugin_name, plugin_name)
                 try:
                     __import__('sqlparse.plugins.{0}'.format(module), {}, {}, ['*'])
                 except Exception:
                     pass
-            if plugins.get_plugin(name):
-                plugin_sections[name] = section
+            if plugins.get_plugin(plugin_name):
+                if plugin_name == 'dialect_strictness':
+                    options['dialect_strictness'] = True
+                    continue
+                if plugin_name == 'spacing_casing' and name == 'keywords':
+                    if plugin_name not in plugin_sections:
+                        plugin_sections[plugin_name] = {}
+                    plugin_sections[plugin_name][name] = section
+                    continue
                 options.pop(name)
+                if plugin_name in ('lists', 'subqueries'):
+                    plugin_sections[plugin_name] = section
+                elif plugin_name == name:
+                    plugin_sections[plugin_name] = {name: section}
+                else:
+                    if plugin_name not in plugin_sections:
+                        plugin_sections[plugin_name] = {}
+                    plugin_sections[plugin_name][name] = section
 
     stack = engine.FilterStack(dialect=dialect)
     options = formatter.validate_options(options)
@@ -86,19 +130,15 @@ def format(sql, encoding=None, **options):
     stack.postprocess.append(filters.SerializerUnicode())
     result = ''.join(stack.run(sql, encoding))
 
-    for key in options:
-        if plugins.get_plugin(key) is None:
-            try:
-                __import__('sqlparse.plugins.{0}'.format(key), fromlist=['_'])
-            except Exception:
-                continue
+    run_options = options.copy()
 
-    for name in plugins.available_plugins():
-        if name in options:
-            plugin_cls = plugins.get_plugin(name)
-            if plugin_cls is not None:
-                plugin = plugin_cls()
-                result = plugin.format(result, options)
+    for name, section in plugin_sections.items():
+        plugin_opts = run_options.copy()
+        plugin_opts.update(section)
+        plugin_cls = plugins.get_plugin(name)
+        if plugin_cls is not None:
+            plugin = plugin_cls()
+            result = plugin.format(result, plugin_opts)
 
     if newline_at_eof is True:
         if not result.endswith('\n'):

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -255,8 +255,10 @@ def build_filter_stack(stack, options):
         if fltr is not None:
             stack.postprocess.append(fltr)
 
-    # Registered plugins
+    # Registered plugins run only when explicitly enabled via options.
     for name in plugins.available_plugins():
+        if name not in options:
+            continue
         plugin_cls = plugins.get_plugin(name)
         if plugin_cls is None:
             continue

--- a/sqlparse/plugins/__init__.py
+++ b/sqlparse/plugins/__init__.py
@@ -52,8 +52,20 @@ def available_plugins():
 # Import bundled plugins so that they register themselves with the registry.
 # Each plugin uses the register_plugin decorator at import time.
 try:  # pragma: no cover - import side effects are tested elsewhere
+    from . import blocks  # noqa: F401
+    from . import case_expr  # noqa: F401
+    from . import clauses  # noqa: F401
+    from . import comments  # noqa: F401
     from . import cte  # noqa: F401
+    from . import create_table  # noqa: F401
     from . import dialect_strictness  # noqa: F401
+    from . import joins  # noqa: F401
+    from . import list_controls  # noqa: F401
+    from . import penalties  # noqa: F401
+    from . import predicates  # noqa: F401
+    from . import spacing_casing  # noqa: F401
+    from . import subqueries  # noqa: F401
 except Exception:
-    # If the plugin fails to import we simply skip registration to keep
+    # If a plugin fails to import we simply skip registration to keep
     # compatibility with minimal environments.
+    pass

--- a/sqlparse/plugins/spacing_casing.py
+++ b/sqlparse/plugins/spacing_casing.py
@@ -1,7 +1,9 @@
 import re
 
+import sqlparse
 from sqlparse import keywords
 from sqlparse import plugins
+from sqlparse import tokens as T
 
 
 class SpacingCasing(object):
@@ -17,11 +19,36 @@ class SpacingCasing(object):
         kw_opts = options.get('keywords') or {}
         case = options.get('keyword_case')
         if case and kw_opts.get('reserved_only'):
-            pattern = r'\b(' + '|'.join(self.RESERVED) + r')\b'
-            def repl(match):
-                word = match.group(0)
-                return getattr(str, case)(word)
-            text = re.sub(pattern, repl, text, flags=re.IGNORECASE)
+            stmts = sqlparse.parse(text)
+            parts = []
+            for stmt in stmts:
+                flat = list(stmt.flatten())
+                for idx, tok in enumerate(flat):
+                    if tok.ttype in T.Keyword and tok.value.upper() in self.RESERVED:
+                        prev = None
+                        j = idx - 1
+                        while j >= 0:
+                            pt = flat[j]
+                            if not pt.is_whitespace:
+                                prev = pt
+                                break
+                            j -= 1
+                        nxt = None
+                        j = idx + 1
+                        length = len(flat)
+                        while j < length:
+                            nt = flat[j]
+                            if not nt.is_whitespace:
+                                nxt = nt
+                                break
+                            j += 1
+                        if prev and prev.match(T.Keyword, 'FROM') and nxt and nxt.ttype in T.Name:
+                            parts.append(tok.value)
+                        else:
+                            parts.append(getattr(str, case)(tok.value))
+                    else:
+                        parts.append(tok.value)
+            text = ''.join(parts)
 
         ident_opts = options.get('identifiers') or {}
         quote_style = ident_opts.get('quote_style')


### PR DESCRIPTION
## Summary
- register bundled formatter plugins on import
- map configuration sections to plugin modules and run them after formatting
- handle reserved keyword casing while preserving table identifiers

## Testing
- `pytest`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_b_689ae16078b0832695aafcadbed7d60e