### PR TITLE
Support symbolic subquery indentation options

### DIFF
--- a/sqlparse/plugins/subqueries.py
+++ b/sqlparse/plugins/subqueries.py
@@ -9,7 +9,20 @@ class Subqueries(object):
 
     def format(self, sql, options):
         open_same = options.get('open_paren_same_line', True)
-        body_indent = int(options.get('body_indent', 2))
+        indent_width = int(options.get('indent_width', 2))
+        cont_indent = int(options.get('continuation_indent', indent_width))
+        body_indent_opt = options.get('body_indent', 2)
+        align_under_open = False
+        if isinstance(body_indent_opt, str):
+            if body_indent_opt == 'plus_one':
+                body_indent = indent_width + cont_indent
+            elif body_indent_opt == 'under_open':
+                body_indent = indent_width
+                align_under_open = True
+            else:
+                body_indent = indent_width
+        else:
+            body_indent = int(body_indent_opt)
         close_align = options.get('close_paren_align_with_open', True)
         prefer_kw_newline = options.get('prefer_keyword_on_newline', False)
 
@@ -40,15 +53,13 @@ class Subqueries(object):
         def calc_indent(text, pos):
             before = text[:pos]
             nl = before.rfind('\n')
-            if nl == -1:
-                return 0
-            line = before[nl + 1:]
+            line = before[nl + 1:] if nl != -1 else before
             stripped = line.lstrip(' ')
-            return len(line) - len(stripped)
+            return len(line) - len(stripped), len(line)
 
         positions = find_subqueries(sql)
         for start, end in reversed(positions):
-            indent = calc_indent(sql, start)
+            indent, open_pos = calc_indent(sql, start)
             inner = sql[start + 1:end]
             formatted = sqlparse.format(inner.strip(), reindent=True,
                                         indent_width=body_indent)
@@ -63,20 +74,23 @@ class Subqueries(object):
                 before = before.rstrip()
                 open_part = '\n' + ' ' * indent + '('
 
+            inner_indent = open_pos + 1 if align_under_open else indent + body_indent
+
             if prefer_kw_newline:
-                inner_text = '\n'.join(' ' * (indent + body_indent) + line
-                                        for line in lines)
+                inner_text = '\n'.join(' ' * inner_indent + line for line in lines)
                 replacement = open_part + '\n' + inner_text
             else:
                 first = lines[0] if lines else ''
                 rest = lines[1:] if len(lines) > 1 else []
-                rest_text = '\n'.join(' ' * (indent + body_indent) + line
-                                       for line in rest)
+                rest_text = '\n'.join(' ' * inner_indent + line for line in rest)
                 replacement = open_part + ' ' + first
                 if rest_text:
                     replacement += '\n' + rest_text
 
-            close_indent = indent if close_align else indent + body_indent
+            if align_under_open:
+                close_indent = open_pos if close_align else inner_indent
+            else:
+                close_indent = indent if close_align else inner_indent
             replacement += '\n' + ' ' * close_indent + ')'
 
             sql = before + replacement + after

--- a/tests/test_subqueries_plugin.py
+++ b/tests/test_subqueries_plugin.py
@@ -30,3 +30,20 @@ def test_subquery_close_paren_indent():
     )
     assert formatted == 'SELECT *\nFROM (\n    SELECT 1\n    ) x'
 
+
+def test_subquery_body_indent_plus_one():
+    sql = 'SELECT * FROM (SELECT 1) x'
+    formatted = sqlparse.format(
+        sql,
+        reindent=True,
+        indent_width=2,
+        continuation_indent=2,
+        subqueries={
+            'open_paren_same_line': True,
+            'body_indent': 'plus_one',
+            'close_paren_align_with_open': False,
+            'prefer_keyword_on_newline': True,
+        },
+    )
+    assert formatted == 'SELECT *\nFROM (\n      SELECT 1\n      ) x'
+


### PR DESCRIPTION
## Summary
- allow `subqueries` formatter plugin to accept symbolic `body_indent` values like `plus_one` and `under_open`
- add regression test for `body_indent: plus_one`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689aedd2471c8326a6ebc233f4c9c90a