### PR TITLE
Handle non-numeric subquery indent option

### DIFF
--- a/sqlparse/plugins/subqueries.py
+++ b/sqlparse/plugins/subqueries.py
@@ -9,7 +9,20 @@ class Subqueries(object):
 
     def format(self, sql, options):
         open_same = options.get('open_paren_same_line', True)
-        body_indent = int(options.get('body_indent', 2))
+        body_indent_opt = options.get('body_indent', 2)
+        if isinstance(body_indent_opt, str):
+            opt = body_indent_opt.lower()
+            if opt == 'plus_one':
+                body_indent = options.get('indent_width', 2)
+            elif opt == 'under_open':
+                body_indent = 0
+            else:
+                try:
+                    body_indent = int(body_indent_opt)
+                except Exception:
+                    body_indent = options.get('indent_width', 2)
+        else:
+            body_indent = int(body_indent_opt)
         close_align = options.get('close_paren_align_with_open', True)
         prefer_kw_newline = options.get('prefer_keyword_on_newline', False)
 
@@ -48,20 +61,21 @@ class Subqueries(object):
 
         positions = find_subqueries(sql)
         for start, end in reversed(positions):
-            indent = calc_indent(sql, start)
             inner = sql[start + 1:end]
+            before = sql[:start]
+            after = sql[end + 1:]
+            if open_same:
+                before_r = before.rstrip()
+                indent = calc_indent(before_r, len(before_r))
+                before = before_r + ' '
+                open_part = '('
+            else:
+                indent = calc_indent(sql, start)
+                before = before.rstrip()
+                open_part = '\n' + ' ' * indent + '('
             formatted = sqlparse.format(inner.strip(), reindent=True,
                                         indent_width=body_indent)
             lines = [l.rstrip() for l in formatted.strip().splitlines()]
-            before = sql[:start]
-            after = sql[end + 1:]
-
-            if open_same:
-                before = before.rstrip() + ' '
-                open_part = '('
-            else:
-                before = before.rstrip()
-                open_part = '\n' + ' ' * indent + '('
 
             if prefer_kw_newline:
                 inner_text = '\n'.join(' ' * (indent + body_indent) + line

--- a/tests/test_subqueries_plugin.py
+++ b/tests/test_subqueries_plugin.py
@@ -28,5 +28,21 @@ def test_subquery_close_paren_indent():
             'prefer_keyword_on_newline': True,
         },
     )
-    assert formatted == 'SELECT *\nFROM (\n    SELECT 1\n    ) x'
+    assert formatted == 'SELECT *\nFROM (\n  SELECT 1\n  ) x'
+
+
+def test_subquery_body_indent_plus_one():
+    sql = 'SELECT * FROM (SELECT 1) x'
+    formatted = sqlparse.format(
+        sql,
+        reindent=True,
+        indent_width=4,
+        subqueries={
+            'open_paren_same_line': True,
+            'body_indent': 'plus_one',
+            'close_paren_align_with_open': True,
+            'prefer_keyword_on_newline': True,
+        },
+    )
+    assert formatted == 'SELECT *\nFROM (\n    SELECT 1\n) x'
 


### PR DESCRIPTION
## Summary
- support `plus_one` and `under_open` values for `subqueries.body_indent`
- compute subquery indentation from preceding line when open paren stays on same line
- cover new indentation behaviour with tests

## Testing
- `PYTHONPATH=. pytest tests/`

------
https://chatgpt.com/codex/tasks/task_b_689b1cabf65c8326b2a612d286fcc840