### PR TITLE
Allow equals-separated config files

### DIFF
--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -91,9 +91,12 @@ def _parse_simple_yaml(text):
             continue
         indent = len(raw) - len(raw.lstrip(' '))
         line = raw.strip()
-        if ':' not in line:
+        if ':' in line:
+            key, value = line.split(':', 1)
+        elif '=' in line:
+            key, value = line.split('=', 1)
+        else:
             continue
-        key, value = line.split(':', 1)
         key = key.strip()
         value = value.strip()
         if value:
@@ -133,7 +136,7 @@ def _parse_yaml(text):
                 return loaded
             return {}
         except Exception:
-            return {}
+            return _parse_simple_yaml(text)
     return _parse_simple_yaml(text)
 
 
@@ -190,6 +193,13 @@ def load_clang_config(path):
         raise ValueError('Unsupported config version: {0}'.format(version))
 
     opts = {}
+
+    for key in DEFAULT_CONFIG:
+        if key in data:
+            val = data[key]
+            if isinstance(val, str) and key in ('keyword_case', 'identifier_case', 'output_format'):
+                val = val.lower()
+            opts[key] = val
 
     # Dialect
     dialect = data.get('dialect')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,14 @@ def test_load_clang_config_preserve(tmpdir):
     assert opts['identifier_case'] == 'preserve'
 
 
+def test_load_clang_config_equals(tmpdir):
+    cfg = tmpdir.join('style.ini')
+    cfg.write('[sqlformat]\nversion = 1\nreindent = true\nkeyword_case = upper\n')
+    opts = config.load_clang_config(str(cfg))
+    assert opts['reindent'] is True
+    assert opts['keyword_case'] == 'upper'
+
+
 def test_load_clang_config_full_sections(tmpdir):
     cfg = tmpdir.join('style_full.yaml')
     cfg.write(


### PR DESCRIPTION
## Summary
- accept `=` separators in config files and fallback to simple parser when YAML parsing fails
- support top-level snake_case options when loading clang-style config files
- add regression test for INI-style config parsing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b8403ef508326baf4ff9668acba09