### PR TITLE
Allow hanging identifier layout

### DIFF
--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -129,7 +129,7 @@ def validate_options(options):  # noqa: C901
     options['align_longest_keyword'] = align_longest_keyword
 
     id_layout = options.get('id_layout', 'vertical')
-    if id_layout not in ['vertical', 'single_line']:
+    if id_layout not in ['vertical', 'single_line', 'hanging']:
         raise SQLParseError('Invalid value for id_layout: '
                             '{!r}'.format(id_layout))
     options['id_layout'] = id_layout

--- a/tests/test_id_layout_hanging.py
+++ b/tests/test_id_layout_hanging.py
@@ -1,0 +1,8 @@
+import sqlparse
+
+
+def test_id_layout_hanging():
+    sql = "select a, b, c from foo;"
+    formatted = sqlparse.format(sql, reindent_aligned=True, id_layout='hanging')
+    assert formatted == "select a,\n       b,\n       c\n  from foo;"
+


### PR DESCRIPTION
## Summary
- permit `id_layout=hanging` in formatting options
- test hanging layout to ensure SQL remains stable

## Testing
- `cat issue/into.esql | PYTHONPATH=. python sqlparse/bin/sqlformat --config issue/example.sqlparse -`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b8802921883269f9d9d3148c30dfd