### PR TITLE
Search home directory for config files

### DIFF
--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -288,7 +288,12 @@ def load_clang_config(path):
 
 
 def find_config(start):
-    """Search for a .sqlparse file starting from *start*."""
+    """Search for a .sqlparse file starting from *start*.
+
+    The search walks up the directory tree until the root directory is
+    reached.  If no configuration file is found, the user's home directory is
+    checked before giving up.
+    """
     if start is None:
         start = os.getcwd()
     if not os.path.isdir(start):
@@ -302,6 +307,9 @@ def find_config(start):
         if parent == current:
             break
         current = parent
+    home_candidate = os.path.join(os.path.expanduser('~'), '.sqlparse')
+    if os.path.isfile(home_candidate):
+        return home_candidate
     return None
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,15 @@ def test_load_config_ignores_comments(tmpdir, monkeypatch):
     assert options['keyword_case'] == 'upper'
 
 
+def test_load_config_home_fallback(tmpdir, monkeypatch):
+    home = tmpdir.mkdir('home')
+    cfg = home.join('.sqlparse')
+    cfg.write('version: 1\nkeywords:\n  case: lower\n')
+    monkeypatch.setenv('HOME', str(home))
+    options = config.load_config(str(tmpdir))
+    assert options['keyword_case'] == 'lower'
+
+
 def test_dump_config():
     opts = config.DEFAULT_CONFIG.copy()
     opts['keyword_case'] = 'upper'


### PR DESCRIPTION
## Summary
- look for `.sqlparse` configs up the directory tree and fall back to the user's home folder
- test that home config is used when no project config exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c4e70f7ec8326be4b9b7f06307535