### PR TITLE
Refactor configuration loading

### DIFF
--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -196,16 +196,13 @@ def main(args=None):
     parser = create_parser()
     args = parser.parse_args(args)
     if args.filename == '-':
-        cfg_path = os.getcwd()
+        start = os.getcwd()
     else:
-        cfg_path = args.filename
-    options = spconfig.DEFAULT_CONFIG.copy()
-    cfg_file = args.config or spconfig.find_config(cfg_path)
-    if cfg_file:
-        try:
-            options.update(spconfig.load_clang_config(cfg_file))
-        except ValueError as e:
-            return _error(str(e))
+        start = args.filename
+    try:
+        options = spconfig.load_config(start, cfg_path=args.config)
+    except ValueError as e:
+        return _error(str(e))
     try:
         options.update(spconfig.load_style(args.style))
     except ValueError as e:

--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -313,9 +313,16 @@ def find_config(start):
     return None
 
 
-def load_config(path):
+def load_config(path, cfg_path=None):
+    """Load options from *cfg_path* or search starting at *path*.
+
+    If *cfg_path* is provided it is used directly as configuration file.
+    Otherwise :func:`find_config` is used to locate a ``.sqlparse`` file
+    beginning at *path*.
+    """
     cfg = DEFAULT_CONFIG.copy()
-    cfg_path = find_config(path)
+    if cfg_path is None:
+        cfg_path = find_config(path)
     if cfg_path:
         cfg.update(load_clang_config(cfg_path))
     return cfg

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,13 @@ def test_load_config(tmpdir):
     assert options['keyword_case'] == 'upper'
 
 
+def test_load_config_file(tmpdir):
+    cfg = tmpdir.join('style.yaml')
+    cfg.write('version: 1\nkeywords:\n  case: lower\n')
+    options = config.load_config(None, str(cfg))
+    assert options['keyword_case'] == 'lower'
+
+
 def test_load_config_ignores_comments(tmpdir, monkeypatch):
     monkeypatch.setattr(config, 'yaml', None)
     cfg_dir = tmpdir.mkdir('cfg_comment')


### PR DESCRIPTION
## Summary
- centralize config file search by enhancing `load_config`
- simplify CLI to use package-level config loading
- add regression test for explicit config file paths

## Testing
- `pytest`
- `flake8` *(missing: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c8598eff483268b3ef4ff7d446449