### PR TITLE
Add verbose flag with configuration source output

### DIFF
--- a/docs/source/ui.rst
+++ b/docs/source/ui.rst
@@ -6,7 +6,9 @@ User Interfaces
   Run :command:`sqlformat --help` to list available options and for usage
   hints.
   It understands a ``--dialect`` (or ``--flavor``) option which selects the
-  SQL dialect to be used.
+  SQL dialect to be used.  Use ``-v``/``--verbose`` to increase output
+  verbosity; each occurrence raises the level (``-vvv`` is level 3) and level
+  1 shows where configuration options were loaded from.
 
 ``sqlformat.appspot.com``
   An example `Google App Engine <https://cloud.google.com/appengine/>`_

--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -7,6 +7,9 @@
 
 """Parse SQL statements."""
 
+# Verbosity level for sqlparse, 0 by default. Higher values increase output.
+verbosity = 0
+
 # Setup namespace
 from sqlparse import sql
 from sqlparse import cli
@@ -18,7 +21,7 @@ from sqlparse import config
 from sqlparse import plugins
 
 __version__ = '0.5.3'
-__all__ = ['engine', 'filters', 'formatter', 'sql', 'tokens', 'cli', 'config', 'plugins']
+__all__ = ['engine', 'filters', 'formatter', 'sql', 'tokens', 'cli', 'config', 'plugins', 'verbosity']
 
 # Mapping from option section names to plugin registry names.
 _OPTION_TO_PLUGIN = {

--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -63,6 +63,13 @@ def create_parser():
         help='Dump configuration and exit')
 
     parser.add_argument(
+        '-v', '--verbose',
+        dest='verbose',
+        action='count',
+        default=0,
+        help='increase verbosity (can be repeated)')
+
+    parser.add_argument(
         '-o', '--outfile',
         dest='outfile',
         metavar='FILE',
@@ -195,23 +202,44 @@ def _error(msg):
 def main(args=None):
     parser = create_parser()
     args = parser.parse_args(args)
+    sqlparse.verbosity = getattr(args, 'verbose', 0)
+
     if args.filename == '-':
         start = os.getcwd()
     else:
         start = args.filename
+
+    cfg_path = args.config if args.config else spconfig.find_config(start)
     try:
-        options = spconfig.load_config(start, cfg_path=args.config)
+        options = spconfig.load_config(start, cfg_path=cfg_path)
     except ValueError as e:
         return _error(str(e))
+    if sqlparse.verbosity >= 1:
+        if cfg_path:
+            sys.stderr.write('[INFO] Loaded configuration from {0}\n'.format(cfg_path))
+        else:
+            sys.stderr.write('[INFO] Using default configuration\n')
+
     try:
-        options.update(spconfig.load_style(args.style))
+        style_opts = spconfig.load_style(args.style)
     except ValueError as e:
         return _error(str(e))
+    if sqlparse.verbosity >= 1:
+        if args.style:
+            if args.style.startswith('{') and args.style.endswith('}'):
+                sys.stderr.write('[INFO] Loaded style from inline definition\n')
+            else:
+                sys.stderr.write('[INFO] Loaded style {0}\n'.format(args.style))
+        else:
+            sys.stderr.write('[INFO] No style specified\n')
+    options.update(style_opts)
 
     arg_dict = vars(args)
     for key in spconfig.DEFAULT_CONFIG.keys():
         if key in arg_dict and arg_dict[key] is not None:
             options[key] = arg_dict[key]
+    if sqlparse.verbosity >= 1:
+        sys.stderr.write('[INFO] Loaded command line options\n')
 
     if args.dump_config:
         sys.stdout.write(spconfig.dump_config(options))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,3 +155,34 @@ def test_default_config(tmpdir, capsys):
     sqlparse.cli.main([str(sqlfile)])
     out, _ = capsys.readouterr()
     assert out.strip() == 'SELECT 1 + 2 AS x;'
+
+
+def test_verbose_level(filepath, capsys, no_config):
+    path = filepath('function.sql')
+    sqlparse.verbosity = 0
+    sqlparse.cli.main([path, '-v'])
+    assert sqlparse.verbosity == 1
+    _, err = capsys.readouterr()
+    assert '[INFO] Using default configuration' in err
+    sqlparse.verbosity = 0
+
+
+def test_verbose_config_source(tmpdir, capsys):
+    sqlfile = tmpdir.join('in.sql')
+    sqlfile.write('select 1;')
+    cfg = tmpdir.join('.sqlparse')
+    cfg.write('version: 1\n')
+    sqlparse.verbosity = 0
+    sqlparse.cli.main([str(sqlfile), '-v'])
+    _, err = capsys.readouterr()
+    assert str(cfg) in err
+    sqlparse.verbosity = 0
+
+
+def test_verbose_style(filepath, capsys, no_config):
+    path = filepath('function.sql')
+    sqlparse.verbosity = 0
+    sqlparse.cli.main([path, '-v', '--style', 'mysql'])
+    _, err = capsys.readouterr()
+    assert '[INFO] Loaded style mysql' in err
+    sqlparse.verbosity = 0


### PR DESCRIPTION
## Summary
- expose package-wide `verbosity` level
- support additive `-v/--verbose` CLI option and show config sources at level 1
- document verbosity feature and add coverage tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689cb8d60568832693416362750bae6a