### PR TITLE
Rename config file to .sqlparse-format

### DIFF
--- a/issue/keyword-align-longest.md
+++ b/issue/keyword-align-longest.md
@@ -278,4 +278,4 @@ Why this works:
 
 ---
 
-If you want, I can turn this into a concrete `issue/example.sqlparse` (INI or toml) and note any minimal formatter hooks you’d need to add (e.g., the two‑pass keyword scan and the `grid` packer).
+If you want, I can turn this into a concrete `issue/example.sqlparse-format` (INI or toml) and note any minimal formatter hooks you’d need to add (e.g., the two‑pass keyword scan and the `grid` packer).

--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -53,7 +53,7 @@ def create_parser():
         '--config',
         dest='config',
         metavar='FILE',
-        help='Read formatting options from YAML FILE (default ".sqlparse")')
+        help='Read formatting options from YAML FILE (default ".sqlparse-format")')
 
     parser.add_argument(
         '--dump-config',

--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -288,7 +288,7 @@ def load_clang_config(path):
 
 
 def find_config(start):
-    """Search for a .sqlparse file starting from *start*.
+    """Search for a .sqlparse-format file starting from *start*.
 
     The search walks up the directory tree until the root directory is
     reached.  If no configuration file is found, the user's home directory is
@@ -300,14 +300,14 @@ def find_config(start):
         start = os.path.dirname(start)
     current = os.path.abspath(start)
     while True:
-        candidate = os.path.join(current, '.sqlparse')
+        candidate = os.path.join(current, '.sqlparse-format')
         if os.path.isfile(candidate):
             return candidate
         parent = os.path.dirname(current)
         if parent == current:
             break
         current = parent
-    home_candidate = os.path.join(os.path.expanduser('~'), '.sqlparse')
+    home_candidate = os.path.join(os.path.expanduser('~'), '.sqlparse-format')
     if os.path.isfile(home_candidate):
         return home_candidate
     return None
@@ -317,7 +317,7 @@ def load_config(path, cfg_path=None):
     """Load options from *cfg_path* or search starting at *path*.
 
     If *cfg_path* is provided it is used directly as configuration file.
-    Otherwise :func:`find_config` is used to locate a ``.sqlparse`` file
+    Otherwise :func:`find_config` is used to locate a ``.sqlparse-format`` file
     beginning at *path*.
     """
     cfg = DEFAULT_CONFIG.copy()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,7 +150,7 @@ def test_config_option(tmpdir, capsys):
 def test_default_config(tmpdir, capsys):
     sqlfile = tmpdir.join('in.sql')
     sqlfile.write('select 1+2 as x;')
-    cfg = tmpdir.join('.sqlparse')
+    cfg = tmpdir.join('.sqlparse-format')
     cfg.write('version: 1\nkeywords:\n  case: upper\nspacing:\n  space_around_operators: true\n')
     sqlparse.cli.main([str(sqlfile)])
     out, _ = capsys.readouterr()
@@ -170,7 +170,7 @@ def test_verbose_level(filepath, capsys, no_config):
 def test_verbose_config_source(tmpdir, capsys):
     sqlfile = tmpdir.join('in.sql')
     sqlfile.write('select 1;')
-    cfg = tmpdir.join('.sqlparse')
+    cfg = tmpdir.join('.sqlparse-format')
     cfg.write('version: 1\n')
     sqlparse.verbosity = 0
     sqlparse.cli.main([str(sqlfile), '-v'])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ def test_load_style():
 
 def test_load_config(tmpdir):
     cfg_dir = tmpdir.mkdir('cfg')
-    cfg_file = cfg_dir.join('.sqlparse')
+    cfg_file = cfg_dir.join('.sqlparse-format')
     cfg_file.write('version: 1\nkeywords:\n  case: upper\n')
     options = config.load_config(str(cfg_dir))
     assert options['keyword_case'] == 'upper'
@@ -28,7 +28,7 @@ def test_load_config_file(tmpdir):
 def test_load_config_ignores_comments(tmpdir, monkeypatch):
     monkeypatch.setattr(config, 'yaml', None)
     cfg_dir = tmpdir.mkdir('cfg_comment')
-    cfg_file = cfg_dir.join('.sqlparse')
+    cfg_file = cfg_dir.join('.sqlparse-format')
     cfg_file.write('version: 1\nkeywords:\n  case: upper   # comment\n')
     options = config.load_config(str(cfg_dir))
     assert options['keyword_case'] == 'upper'
@@ -36,7 +36,7 @@ def test_load_config_ignores_comments(tmpdir, monkeypatch):
 
 def test_load_config_home_fallback(tmpdir, monkeypatch):
     home = tmpdir.mkdir('home')
-    cfg = home.join('.sqlparse')
+    cfg = home.join('.sqlparse-format')
     cfg.write('version: 1\nkeywords:\n  case: lower\n')
     monkeypatch.setenv('HOME', str(home))
     options = config.load_config(str(tmpdir))
@@ -67,7 +67,7 @@ def test_load_clang_config_newline_at_eof(tmpdir):
 
 def test_load_config_preserve(tmpdir):
     cfg_dir = tmpdir.mkdir('cfg_preserve')
-    cfg_file = cfg_dir.join('.sqlparse')
+    cfg_file = cfg_dir.join('.sqlparse-format')
     cfg_file.write('version: 1\nkeywords:\n  case: preserve\nidentifiers:\n  case: preserve\n')
     options = config.load_config(str(cfg_dir))
     assert options['keyword_case'] == 'preserve'
@@ -160,7 +160,7 @@ def test_load_clang_config_full_sections(tmpdir):
 
 
 def test_format_uses_config_file(tmpdir, monkeypatch):
-    cfg = tmpdir.join('.sqlparse')
+    cfg = tmpdir.join('.sqlparse-format')
     cfg.write('version: 1\nkeywords:\n  case: upper\nidentifiers:\n  case: upper\n')
     monkeypatch.chdir(str(tmpdir))
     formatted = sqlparse.format('select foo')

--- a/tests/test_formatter_config.py
+++ b/tests/test_formatter_config.py
@@ -2,7 +2,7 @@ import sqlparse
 from sqlparse import config
 
 def test_format_applies_clang_config(tmpdir):
-    cfg = tmpdir.join('.sqlparse')
+    cfg = tmpdir.join('.sqlparse-format')
     cfg.write(
         'version: 1\n'
         'dialect:\n  mode: postgres\n'


### PR DESCRIPTION
## Summary
- look for `.sqlparse-format` config files instead of `.sqlparse`
- update CLI help text and tests for the new config filename

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689d1d8ad7e08326bb1317d28b5236f5