### PR TITLE
Use YAML configuration exclusively

### DIFF
--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -56,12 +56,7 @@ _PLUGIN_MODULES = {
 def get_config(path=None, cfg_path=None, style=None, include_defaults=True, **options):
     if cfg_path is None:
         cfg_path = config.find_config(path)
-    if include_defaults:
-        cfg = config.load_config(path, cfg_path=cfg_path)
-    else:
-        cfg = {}
-        if cfg_path:
-            cfg.update(config.load_clang_config(cfg_path))
+    cfg = config.load_config(path, cfg_path=cfg_path, include_defaults=include_defaults)
     if verbosity >= 1:
         if cfg_path:
             sys.stderr.write('[INFO] Loaded configuration from {0}\n'.format(cfg_path))

--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -47,38 +47,6 @@ PREDEFINED_STYLES = {
     'mysql': {'keyword_case': 'upper'},
 }
 
-# Mapping from config file keys to internal names
-KEY_MAP = {
-    'Dialect': 'dialect',
-    'Flavor': 'dialect',
-    'KeywordCase': 'keyword_case',
-    'IdentifierCase': 'identifier_case',
-    'OutputFormat': 'output_format',
-    'StripComments': 'strip_comments',
-    'Reindent': 'reindent',
-    'IndentWidth': 'indent_width',
-    'IndentAfterFirst': 'indent_after_first',
-    'IndentColumns': 'indent_columns',
-    'ReindentAligned': 'reindent_aligned',
-    'UseSpaceAroundOperators': 'use_space_around_operators',
-    'SpacesInParens': 'spaces_in_parens',
-    'SpacesInBrackets': 'spaces_in_brackets',
-    'SpaceBeforeCallParen': 'space_before_call_paren',
-    'WrapAfter': 'wrap_after',
-    'CommaFirst': 'comma_first',
-    'Compact': 'compact',
-    'IndentTabs': 'indent_tabs',
-    'StripWhitespace': 'strip_whitespace',
-    'TruncateStrings': 'truncate_strings',
-    'TruncateChar': 'truncate_char',
-    'RightMargin': 'right_margin',
-    'PadAfterKeyword': 'pad_after_keyword',
-    'AlignLongestKeyword': 'align_longest_keyword',
-    'IdLayout': 'id_layout',
-    'StripTrailingWhitespace': 'strip_trailing_whitespace',
-    'BasedOnStyle': 'BasedOnStyle',
-}
-
 BOOL_TRUE = ['true', 'yes', 'on']
 BOOL_FALSE = ['false', 'no', 'off']
 
@@ -144,45 +112,8 @@ def _parse_yaml(text):
     return _parse_simple_yaml(text)
 
 
-def load_from_file(path):
-    """Load options from a configuration file."""
-    try:
-        stream = open(path, 'r')
-        try:
-            text = stream.read()
-        finally:
-            stream.close()
-    except OSError:
-        return {}
-    data = _parse_yaml(text) or {}
-    return _convert_keys(data)
-
-
-def load_from_string(text):
-    data = _parse_yaml(text) or {}
-    return _convert_keys(data)
-
-
-def _convert_keys(data):
-    result = {}
-    based = data.pop('BasedOnStyle', None)
-    if based:
-        base = PREDEFINED_STYLES.get(str(based).lower())
-        if base is None:
-            base = {}
-        result.update(base)
-    for key, value in data.items():
-        mapped = KEY_MAP.get(key)
-        if mapped and mapped != 'BasedOnStyle':
-            if isinstance(value, str) and mapped in (
-                    'keyword_case', 'identifier_case', 'output_format'):
-                value = value.lower()
-            result[mapped] = value
-    return result
-
-
-def load_clang_config(path):
-    """Load options from a clang-style YAML configuration."""
+def _load_config_file(path):
+    """Load options from a YAML configuration file."""
     try:
         stream = open(path, 'r')
         try:
@@ -313,18 +244,20 @@ def find_config(start):
     return None
 
 
-def load_config(path, cfg_path=None):
+def load_config(path=None, cfg_path=None, include_defaults=True):
     """Load options from *cfg_path* or search starting at *path*.
 
     If *cfg_path* is provided it is used directly as configuration file.
     Otherwise :func:`find_config` is used to locate a ``.sqlparse-format`` file
     beginning at *path*.
+
+    Set *include_defaults* to ``False`` to omit default options.
     """
-    cfg = DEFAULT_CONFIG.copy()
+    cfg = DEFAULT_CONFIG.copy() if include_defaults else {}
     if cfg_path is None:
         cfg_path = find_config(path)
     if cfg_path:
-        cfg.update(load_clang_config(cfg_path))
+        cfg.update(_load_config_file(cfg_path))
     return cfg
 
 
@@ -332,7 +265,12 @@ def load_style(style):
     if not style or style == 'file':
         return {}
     if style.startswith('{') and style.endswith('}'):
-        return load_from_string(style)
+        data = _parse_yaml(style) or {}
+        for key in ('keyword_case', 'identifier_case', 'output_format'):
+            val = data.get(key)
+            if isinstance(val, str):
+                data[key] = val.lower()
+        return data
     style_lower = style.lower()
     found = PREDEFINED_STYLES.get(style_lower)
     if found is None:
@@ -341,12 +279,10 @@ def load_style(style):
 
 
 def dump_config(options):
-    lines = []
-    for key, snake in KEY_MAP.items():
-        if snake == 'BasedOnStyle':
-            continue
-        if snake in options and options[snake] is not None:
-            value = options[snake]
+    lines = ['version: 1']
+    for key in DEFAULT_CONFIG:
+        if key in options and options[key] is not None:
+            value = options[key]
             if isinstance(value, bool):
                 value = 'true' if value else 'false'
             lines.append('{0}: {1}'.format(key, value))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,7 +126,7 @@ def test_dump_config(filepath, capsys):
     path = filepath('function.sql')
     sqlparse.cli.main([path, '--dump-config'])
     out, _ = capsys.readouterr()
-    assert 'IndentWidth: 2' in out
+    assert 'indent_width: 2' in out
 
 
 def test_style_option(filepath, load_file, capsys, no_config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,21 +47,30 @@ def test_dump_config():
     opts = config.DEFAULT_CONFIG.copy()
     opts['keyword_case'] = 'upper'
     dumped = config.dump_config(opts)
-    assert 'KeywordCase: upper' in dumped
+    assert 'keyword_case: upper' in dumped
 
 
-def test_load_clang_config(tmpdir):
+def test_load_config_default_options(tmpdir):
+    cfg = tmpdir.join('extra.yaml')
+    cfg.write('version: 1\npad_after_keyword: 2\nalign_longest_keyword: true\nright_margin: 80\n')
+    opts = config.load_config(None, str(cfg), include_defaults=False)
+    assert opts['pad_after_keyword'] == 2
+    assert opts['align_longest_keyword'] is True
+    assert opts['right_margin'] == 80
+
+
+def test_load_config_direct(tmpdir):
     cfg = tmpdir.join('style.yaml')
     cfg.write('version: 1\nlayout:\n  indent_width: 3\nkeywords:\n  case: lower\n')
-    opts = config.load_clang_config(str(cfg))
+    opts = config.load_config(None, str(cfg), include_defaults=False)
     assert opts['indent_width'] == 3
     assert opts['keyword_case'] == 'lower'
 
 
-def test_load_clang_config_newline_at_eof(tmpdir):
+def test_load_config_newline_at_eof(tmpdir):
     cfg = tmpdir.join('newline.yaml')
     cfg.write('version: 1\nlayout:\n  newline_at_eof: true\n')
-    opts = config.load_clang_config(str(cfg))
+    opts = config.load_config(None, str(cfg), include_defaults=False)
     assert opts['newline_at_eof'] is True
 
 
@@ -74,23 +83,23 @@ def test_load_config_preserve(tmpdir):
     assert options['identifier_case'] == 'preserve'
 
 
-def test_load_clang_config_preserve(tmpdir):
+def test_load_config_preserve_direct(tmpdir):
     cfg = tmpdir.join('style_preserve.yaml')
     cfg.write('version: 1\nkeywords:\n  case: preserve\nidentifiers:\n  case: preserve\n')
-    opts = config.load_clang_config(str(cfg))
+    opts = config.load_config(None, str(cfg), include_defaults=False)
     assert opts['keyword_case'] == 'preserve'
     assert opts['identifier_case'] == 'preserve'
 
 
-def test_load_clang_config_equals(tmpdir):
+def test_load_config_equals(tmpdir):
     cfg = tmpdir.join('style.ini')
     cfg.write('[sqlformat]\nversion = 1\nreindent = true\nkeyword_case = upper\n')
-    opts = config.load_clang_config(str(cfg))
+    opts = config.load_config(None, str(cfg), include_defaults=False)
     assert opts['reindent'] is True
     assert opts['keyword_case'] == 'upper'
 
 
-def test_load_clang_config_full_sections(tmpdir):
+def test_load_config_full_sections(tmpdir):
     cfg = tmpdir.join('style_full.yaml')
     cfg.write(
         'version: 1\n'
@@ -134,7 +143,7 @@ def test_load_clang_config_full_sections(tmpdir):
         'penalties:\n'
         '  over_column_limit: 500\n'
     )
-    opts = config.load_clang_config(str(cfg))
+    opts = config.load_config(None, str(cfg), include_defaults=False)
     assert opts['indent_width'] == 4
     assert opts['indent_tabs'] is True
     assert opts['spaces_in_parens'] is True

--- a/tests/test_formatter_config.py
+++ b/tests/test_formatter_config.py
@@ -1,7 +1,7 @@
 import sqlparse
 from sqlparse import config
 
-def test_format_applies_clang_config(tmpdir):
+def test_format_applies_yaml_config(tmpdir):
     cfg = tmpdir.join('.sqlparse-format')
     cfg.write(
         'version: 1\n'


### PR DESCRIPTION
## Summary
- remove legacy key-based configuration parsing
- parse and dump only YAML config files
- ensure YAML configs handle pad_after_keyword, align_longest_keyword, and right_margin
- consolidate configuration loading into a single YAML-based function

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689d509cfd7c8326a0661553a53c6634