### PR TITLE
Ensure configuration precedence order

### DIFF
--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -56,7 +56,9 @@ _PLUGIN_MODULES = {
 def get_config(path=None, cfg_path=None, style=None, include_defaults=True, **options):
     if cfg_path is None:
         cfg_path = config.find_config(path)
-    cfg = config.load_config(path, cfg_path=cfg_path, include_defaults=include_defaults)
+    cfg = config.DEFAULT_CONFIG.copy()
+    if cfg_path:
+        cfg.update(config.load_config(cfg_path=cfg_path, include_defaults=False))
     if verbosity >= 1:
         if cfg_path:
             sys.stderr.write('[INFO] Loaded configuration from {0}\n'.format(cfg_path))
@@ -79,6 +81,9 @@ def get_config(path=None, cfg_path=None, style=None, include_defaults=True, **op
         cfg.update(options)
         if verbosity >= 1:
             sys.stderr.write('[INFO] Loaded command line options\n')
+    if not include_defaults:
+        cfg = {k: v for k, v in cfg.items()
+               if k not in config.DEFAULT_CONFIG or v != config.DEFAULT_CONFIG[k]}
     return cfg
 
 
@@ -90,7 +95,7 @@ def parse(sql, encoding=None, dialect=None, **kwargs):
     :returns: A tuple of :class:`~sqlparse.sql.Statement` instances.
     """
     if dialect is None:
-        dialect = get_config(include_defaults=False, **kwargs).get('dialect')
+        dialect = get_config(**kwargs).get('dialect')
     return tuple(parsestream(sql, encoding, dialect, **kwargs))
 
 
@@ -102,7 +107,7 @@ def parsestream(stream, encoding=None, dialect=None, **kwargs):
     :returns: A generator of :class:`~sqlparse.sql.Statement` instances.
     """
     if dialect is None:
-        dialect = get_config(include_defaults=False, **kwargs).get('dialect')
+        dialect = get_config(**kwargs).get('dialect')
     stack = engine.FilterStack(dialect=dialect)
     stack.enable_grouping()
     return stack.run(stream, encoding)
@@ -203,6 +208,6 @@ def split(sql, encoding=None, dialect=None, strip_semicolon=False, **kwargs):
     :returns: A list of strings.
     """
     if dialect is None:
-        dialect = get_config(include_defaults=False, **kwargs).get('dialect')
+        dialect = get_config(**kwargs).get('dialect')
     stack = engine.FilterStack(dialect=dialect, strip_semicolon=strip_semicolon)
     return [str(stmt).strip() for stmt in stack.run(sql, encoding)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,6 +157,16 @@ def test_default_config(tmpdir, capsys):
     assert out.strip() == 'SELECT 1 + 2 AS x;'
 
 
+def test_cli_overrides_config(tmpdir, capsys):
+    sqlfile = tmpdir.join('in.sql')
+    sqlfile.write('select 1+2 as x;')
+    cfg = tmpdir.join('.sqlparse-format')
+    cfg.write('version: 1\nkeywords:\n  case: upper\n')
+    sqlparse.cli.main([str(sqlfile), '--keywords', 'lower'])
+    out, _ = capsys.readouterr()
+    assert out.strip() == 'select 1+2 as x;'
+
+
 def test_verbose_level(filepath, capsys, no_config):
     path = filepath('function.sql')
     sqlparse.verbosity = 0


### PR DESCRIPTION
## Summary
- load default options and layer config file and command-line overrides
- include default dialect in parsing helpers
- verify CLI options override configuration file settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689d5d90f4f88326b40a5d2390c74fa4