### PR TITLE
Add debug prints to plugin format functions

### DIFF
--- a/sqlparse/plugins/blocks.py
+++ b/sqlparse/plugins/blocks.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import re
+import sys
 from sqlparse import plugins
 
 
@@ -12,6 +13,7 @@ class BlocksPlugin(object):
     """
 
     def format(self, stream, options):
+        print(": sqlparse.plugins.blocks.format(...)", file=sys.stderr)
         text = stream
         if isinstance(stream, (list, tuple)):
             text = ''.join(stream)

--- a/sqlparse/plugins/case_expr.py
+++ b/sqlparse/plugins/case_expr.py
@@ -6,6 +6,7 @@ from sqlparse import parse
 from sqlparse.sql import Case
 from sqlparse import plugins
 from sqlparse import tokens as T
+import sys
 
 try:
     unicode
@@ -29,6 +30,7 @@ class CaseExpressionFormatter(object):
     """
 
     def format(self, stream, options):
+        print(": sqlparse.plugins.case_expr.format(...)", file=sys.stderr)
         # Allow passing either the whole options dict or the case_expr section.
         case_opts = options.get('case_expr') if isinstance(options, dict) else None
         if case_opts is None:

--- a/sqlparse/plugins/clauses.py
+++ b/sqlparse/plugins/clauses.py
@@ -1,3 +1,4 @@
+import sys
 from sqlparse import plugins
 
 
@@ -15,6 +16,7 @@ class Clauses(object):
 
     def format(self, stream, options):
         """Format *stream* according to clause options in *options*."""
+        print(": sqlparse.plugins.clauses.format(...)", file=sys.stderr)
         text = stream
         if isinstance(stream, (list, tuple)):
             text = ''.join(stream)

--- a/sqlparse/plugins/comments.py
+++ b/sqlparse/plugins/comments.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import re
+import sys
 
 from sqlparse import plugins
 
@@ -26,6 +27,7 @@ class CommentFormatter(object):
     """
 
     def format(self, sql, options):
+        print(": sqlparse.plugins.comments.format(...)", file=sys.stderr)
         opts = options or {}
         if 'comments' in opts:
             opts = opts.get('comments') or {}

--- a/sqlparse/plugins/create_table.py
+++ b/sqlparse/plugins/create_table.py
@@ -1,3 +1,4 @@
+import sys
 from sqlparse import plugins
 
 
@@ -12,6 +13,7 @@ class CreateTablePlugin(object):
     """
 
     def format(self, stream, options):
+        print(": sqlparse.plugins.create_table.format(...)", file=sys.stderr)
         if isinstance(stream, str):
             sql = stream
         else:

--- a/sqlparse/plugins/cte.py
+++ b/sqlparse/plugins/cte.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import re
+import sys
 
 from sqlparse import plugins
 
@@ -18,6 +19,7 @@ class CTEFormatter(object):
     """
 
     def format(self, sql, options):  # pragma: no cover - exercised via tests
+        print(": sqlparse.plugins.cte.format(...)", file=sys.stderr)
         cte_opts = options.get('cte') or {}
         if not cte_opts:
             return sql

--- a/sqlparse/plugins/dialect_strictness.py
+++ b/sqlparse/plugins/dialect_strictness.py
@@ -1,3 +1,4 @@
+import sys
 from sqlparse import plugins, keywords, tokens as T
 
 @plugins.register_plugin('dialect_strictness')
@@ -5,6 +6,7 @@ class DialectStrictness(object):
     """Handle dialect.strict_keywords and layout.continuation_indent."""
 
     def format(self, stream, options):
+        print(": sqlparse.plugins.dialect_strictness.format(...)", file=sys.stderr)
         if hasattr(stream, 'token_next'):
             return self._postprocess(stream, options)
         return self._preprocess(stream, options)

--- a/sqlparse/plugins/joins.py
+++ b/sqlparse/plugins/joins.py
@@ -1,5 +1,6 @@
 import re
 import warnings
+import sys
 
 import sqlparse
 from sqlparse import plugins
@@ -15,6 +16,7 @@ class JoinPlugin(object):
         ``joins`` dictionary with the keys ``join_on_new_line``,
         ``align_on_under_join`` and ``prefer_explicit``.
         """
+        print(": sqlparse.plugins.joins.format(...)", file=sys.stderr)
         if stream is None:
             return stream
 

--- a/sqlparse/plugins/list_controls.py
+++ b/sqlparse/plugins/list_controls.py
@@ -1,4 +1,5 @@
 import re
+import sys
 
 from sqlparse import plugins
 
@@ -12,6 +13,7 @@ class ListControls(object):
     """
 
     def format(self, stream, options):
+        print(": sqlparse.plugins.list_controls.format(...)", file=sys.stderr)
         sql = stream if isinstance(stream, str) else ''.join(stream)
 
         # bin_pack: collapse multi-line lists into a single line

--- a/sqlparse/plugins/penalties.py
+++ b/sqlparse/plugins/penalties.py
@@ -7,6 +7,7 @@ values can influence formatting without touching the core formatter.
 The implementation is intentionally small and compatible with Python 3.2.5.
 """
 
+import sys
 import sqlparse
 from sqlparse import plugins
 from sqlparse import sql, tokens as T
@@ -23,6 +24,7 @@ class PenaltyTuning(object):
     """
 
     def format(self, stream, options):
+        print(": sqlparse.plugins.penalties.format(...)", file=sys.stderr)
         penalties = options.get('penalties') or {}
         if isinstance(stream, str):
             statements = sqlparse.parse(stream)

--- a/sqlparse/plugins/predicates.py
+++ b/sqlparse/plugins/predicates.py
@@ -1,6 +1,7 @@
 """Predicate layout plugin."""
 
 import re
+import sys
 
 from sqlparse import plugins
 
@@ -15,6 +16,7 @@ class PredicateLayout(object):
     """
 
     def format(self, stream, options):
+        print(": sqlparse.plugins.predicates.format(...)", file=sys.stderr)
         opts = options.get('predicates')
         if not isinstance(opts, dict):
             return stream

--- a/sqlparse/plugins/spacing_casing.py
+++ b/sqlparse/plugins/spacing_casing.py
@@ -1,4 +1,5 @@
 import re
+import sys
 
 import sqlparse
 from sqlparse import keywords
@@ -12,6 +13,7 @@ class SpacingCasing(object):
     RESERVED = set(k.upper() for k in keywords.KEYWORDS_COMMON.keys())
 
     def format(self, text, options):
+        print(": sqlparse.plugins.spacing_casing.format(...)", file=sys.stderr)
         spacing = options.get('spacing') or {}
         if spacing.get('compact_bool_not'):
             text = re.sub(r'\bNOT\s+\(', 'NOT(', text, flags=re.IGNORECASE)

--- a/sqlparse/plugins/subqueries.py
+++ b/sqlparse/plugins/subqueries.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import sys
 import sqlparse
 from sqlparse import plugins
 
@@ -8,6 +9,7 @@ class Subqueries(object):
     """Very small formatter for subquery placement."""
 
     def format(self, sql, options):
+        print(": sqlparse.plugins.subqueries.format(...)", file=sys.stderr)
         open_same = options.get('open_paren_same_line', True)
         body_indent_opt = options.get('body_indent', 2)
         if isinstance(body_indent_opt, str):


### PR DESCRIPTION
## Summary
- log plugin format() calls to stderr for tracing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689dc6fbde04832687ef1f568d63a4ec