### PR TITLE
Ensure subquery keywords respect pad_after_keyword

### DIFF
--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -126,7 +126,6 @@ def format(sql, encoding=None, **options):
 
     :returns: The formatted SQL statement as string.
     """
-    print('*** sqlparse.format', file=sys.stderr)
     path = options.pop('path', None)
     cfg_path = options.pop('cfg_path', None)
     style = options.pop('style', None)

--- a/sqlparse/filters/aligned_indent.py
+++ b/sqlparse/filters/aligned_indent.py
@@ -73,6 +73,7 @@ class AlignedIndentFilter:
         if token is not None:
             with indent(self):
                 tlist.insert_after(tlist[0], self.nl('SELECT'))
+                self._pad_after_keyword(tlist, token, initial=True)
                 # process the inside of the parenthesis
                 self._process_default(tlist)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -173,7 +173,7 @@ def test_verbose_level(filepath, capsys, no_config):
     sqlparse.cli.main([path, '-v'])
     assert sqlparse.verbosity == 1
     _, err = capsys.readouterr()
-    assert '[INFO] Using default configuration' in err
+    assert '[INFO] Seeding with default configuration' in err
     sqlparse.verbosity = 0
 
 

--- a/tests/test_pad_after_keyword_subquery.py
+++ b/tests/test_pad_after_keyword_subquery.py
@@ -1,0 +1,25 @@
+import sqlparse
+
+
+def test_pad_after_keyword_in_subquery():
+    sql = ("SELECT count(*)\n"
+           "FROM table1\n"
+           "WHERE id = (\n"
+           "    SELECT uidproduct\n"
+           "    FROM table2\n"
+           ")\n")
+    formatted = sqlparse.format(
+        sql,
+        reindent_aligned=True,
+        pad_after_keyword=2,
+        initial_pad_after_keyword=2,
+    )
+    assert formatted == (
+        "SELECT  count(*)\n"
+        "  FROM  table1\n"
+        " WHERE  id = (\n"
+        "        SELECT  uidproduct\n"
+        "          FROM  table2\n"
+        "       )"
+    )
+


### PR DESCRIPTION
## Summary
- correct subquery handling so `pad_after_keyword` applies to nested `SELECT`
- drop stray debug output from `format` and update CLI test
- add regression test for keyword padding inside subqueries

## Testing
- `pytest tests/test_pad_after_keyword_subquery.py -q`
- `pytest tests/test_cli.py::test_invalid_args tests/test_cli.py::test_verbose_level -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ddd4c84c083269fd9d7bc73f86e97