### PR TITLE
Preserve DECLARE CURSOR clauses on one line

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 Development Version
 -------------------
 
-Nothing yet.
-
+* Preserve DECLARE CURSOR clauses on a single line and add
+  `declare_cursor_break_before` option.
 
 Release 0.5.3 (Dez 10, 2024)
 ----------------------------

--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -171,6 +171,13 @@ def create_parser():
         help='Insert linebreak before comma (default False)')
 
     group.add_argument(
+        '--declare_cursor_break_before',
+        dest='declare_cursor_break_before',
+        action='store_true',
+        default=None,
+        help='Insert linebreak before DECLARE CURSOR statements')
+
+    group.add_argument(
         '--compact',
         dest='compact',
         default=None,

--- a/sqlparse/config.py
+++ b/sqlparse/config.py
@@ -38,6 +38,7 @@ DEFAULT_CONFIG = {
     'truncate_strings': None,
     'truncate_char': '[...]',
     'right_margin': None,
+    'declare_cursor_break_before': False,
 }
 
 # Predefined styles

--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -12,7 +12,8 @@ from sqlparse.utils import offset, indent
 class ReindentFilter:
     def __init__(self, width=2, char=' ', wrap_after=0, n='\n',
                  comma_first=False, indent_after_first=False,
-                 indent_columns=False, compact=False):
+                 indent_columns=False, compact=False,
+                 declare_cursor_break_before=False):
         self.n = n
         self.width = width
         self.char = char
@@ -22,6 +23,7 @@ class ReindentFilter:
         self.comma_first = comma_first
         self.indent_columns = indent_columns
         self.compact = compact
+        self.declare_cursor_break_before = declare_cursor_break_before
         self._curr_stmt = None
         self._last_stmt = None
         self._last_func = None
@@ -52,11 +54,13 @@ class ReindentFilter:
             self.n + self.char * max(0, self.leading_ws + offset))
 
     def _next_token(self, tlist, idx=-1):
-        split_words = ('FROM', 'STRAIGHT_JOIN$', 'JOIN$', 'AND', 'OR',
+        split_words = ['FROM', 'STRAIGHT_JOIN$', 'JOIN$', r'^AND$', r'^OR$',
                        'GROUP BY', 'ORDER BY', 'UNION', 'VALUES',
                        'SET', 'BETWEEN', 'EXCEPT', 'HAVING', 'LIMIT',
-                       'INTO')
-        m_split = T.Keyword, split_words, True
+                       'INTO']
+        if self.declare_cursor_break_before:
+            split_words.append(r'^DECLARE$')
+        m_split = T.Keyword, tuple(split_words), True
         tidx, token = tlist.token_next_by(m=m_split, idx=idx)
 
         if token and token.normalized == 'BETWEEN':

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -212,6 +212,11 @@ def validate_options(options):  # noqa: C901
         raise SQLParseError('compact requires a boolean value')
     options['compact'] = compact
 
+    declare_cursor_break_before = options.get('declare_cursor_break_before', False)
+    if declare_cursor_break_before not in [True, False]:
+        raise SQLParseError('declare_cursor_break_before requires a boolean value')
+    options['declare_cursor_break_before'] = declare_cursor_break_before
+
     right_margin = options.get('right_margin')
     if right_margin is not None:
         try:
@@ -278,7 +283,8 @@ def build_filter_stack(stack, options):
                 indent_columns=options['indent_columns'],
                 wrap_after=options['wrap_after'],
                 comma_first=options['comma_first'],
-                compact=options['compact'],))
+                compact=options['compact'],
+                declare_cursor_break_before=options['declare_cursor_break_before'],))
 
     if options.get('reindent_aligned', False):
         stack.enable_grouping()

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -660,6 +660,20 @@ class TestFormatReindent:
             'from employees',
             'where employee_id = :id;'])
 
+    def test_declare_cursor_default(self):
+        sql = 'EXEC SQL AT :server_alias DECLARE csr CURSOR FOR SELECT foo'
+        formatted = sqlparse.format(sql, reindent=True)
+        assert formatted == ('EXEC SQL AT :server_alias DECLARE csr CURSOR FOR\n'
+                             'SELECT foo')
+
+    def test_declare_cursor_break_before(self):
+        sql = 'EXEC SQL AT :server_alias DECLARE csr CURSOR FOR SELECT foo'
+        formatted = sqlparse.format(
+            sql, reindent=True, declare_cursor_break_before=True)
+        assert formatted == ('EXEC SQL AT :server_alias\n'
+                             'DECLARE csr CURSOR FOR\n'
+                             'SELECT foo')
+
 
 class TestOutputFormat:
     def test_python(self):


### PR DESCRIPTION
## Summary
- keep DECLARE CURSOR FOR clauses on a single line
- add `declare_cursor_break_before` formatter option and CLI flag
- document new behavior in changelog and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ded73267c8326bfa81d4d4f97ee02