### PR TITLE
feat: auto-discover formatter plugins

### DIFF
--- a/doc/Formatting-Plugin-Architecture.md
+++ b/doc/Formatting-Plugin-Architecture.md
@@ -5,6 +5,12 @@ sqlparse provides a lightweight plugin registry located at
 `sqlparse/plugins/__init__.py`. Each formatter enhancement can live in its own
 module and register itself with the registry without modifying shared code.
 
+Plugins are discovered lazily.  Bundled plugins are located by scanning the
+``sqlparse.plugins`` package, while third-party plugins can advertise
+themselves via the ``sqlparse.plugins`` entry point group.  Discovery happens on
+first access so simply installing a package exposing an entry point makes the
+plugin available without touching the core library.
+
 ## Writing a plugin
 
 1. Create a module inside `sqlparse/plugins/`.
@@ -22,6 +28,16 @@ class CustomOption(object):
 ```
 
 4. Add tests demonstrating the plugin behaviour.
+
+To publish a plugin in a separate package add an entry point to your
+``pyproject.toml``::
+
+    [project.entry-points."sqlparse.plugins"]
+    my_plugin = "mypackage.module:PluginClass"
+
+Users may control which plugins load by defining the environment variables
+``SQLPARSE_ENABLED_PLUGINS`` or ``SQLPARSE_DISABLED_PLUGINS`` with comma
+separated plugin names.
 
 ## Development guidelines
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,7 @@ Tracker = "https://github.com/andialbrecht/sqlparse/issues"
 [project.scripts]
 sqlformat = "sqlparse.__main__:main"
 
+[project.entry-points."sqlparse.plugins"]
+# Entry points allow third-party packages to register formatter plugins.
+# Built-in plugins are discovered automatically and do not need to be listed.
+

--- a/sqlparse/plugins/__init__.py
+++ b/sqlparse/plugins/__init__.py
@@ -3,10 +3,24 @@
 This lightweight registry allows formatter features to be developed as
 standalone plugins. Each plugin registers itself with a unique name so that
 multiple teams can work on separate features concurrently without touching
-shared state.
+shared state.  Registration happens automatically through a discovery
+mechanism so that new plugins can be added without modifying this file.
 """
 
+import importlib
+import os
+import pkgutil
+
+try:  # pragma: no cover - dependency optional on old Pythons
+    from importlib import metadata as importlib_metadata
+except Exception:  # pragma: no cover
+    try:  # type: ignore
+        import importlib_metadata as importlib_metadata
+    except Exception:  # pragma: no cover
+        importlib_metadata = None  # type: ignore
+
 _registry = {}
+_discovered = False
 
 
 def register_plugin(name, plugin_cls=None):
@@ -29,15 +43,70 @@ def register_plugin(name, plugin_cls=None):
     return plugin_cls
 
 
+def _should_load(name, enabled, disabled):
+    if name.startswith('_'):
+        return False
+    if enabled and name not in enabled:
+        return False
+    if name in disabled:
+        return False
+    return True
+
+
+def _discover_bundled(enabled, disabled):
+    for mod in pkgutil.iter_modules(__path__):
+        name = mod.name
+        if not _should_load(name, enabled, disabled):
+            continue
+        try:
+            importlib.import_module('%s.%s' % (__name__, name))
+        except Exception:
+            continue
+
+
+def _discover_entry_points(enabled, disabled):
+    if importlib_metadata is None:  # pragma: no cover
+        return
+    try:
+        eps = importlib_metadata.entry_points()
+        if hasattr(eps, 'select'):
+            eps = eps.select(group='sqlparse.plugins')
+        else:  # pragma: no cover - older importlib_metadata API
+            eps = eps.get('sqlparse.plugins', [])
+    except Exception:  # pragma: no cover
+        return
+    for ep in eps:
+        name = ep.name
+        if not _should_load(name, enabled, disabled):
+            continue
+        try:
+            plugin = ep.load()
+        except Exception:
+            continue
+        register_plugin(name, plugin)
+
+
+def _ensure_plugins_loaded():
+    global _discovered
+    if _discovered:
+        return
+    _discovered = True
+    enabled = set(filter(None, os.environ.get('SQLPARSE_ENABLED_PLUGINS', '').split(',')))
+    disabled = set(filter(None, os.environ.get('SQLPARSE_DISABLED_PLUGINS', '').split(',')))
+    _discover_bundled(enabled, disabled)
+    _discover_entry_points(enabled, disabled)
+
+
 def get_plugin(name):
     """Return the plugin class registered under *name* or *None*.
 
     Parameters are intentionally simple for compatibility with Python 3.2.5.
     """
+    _ensure_plugins_loaded()
     cls = _registry.get(name)
     if cls is None:
         try:
-            __import__('sqlparse.plugins.{0}'.format(name))
+            importlib.import_module('sqlparse.plugins.{0}'.format(name))
         except Exception:
             return None
         cls = _registry.get(name)
@@ -46,26 +115,5 @@ def get_plugin(name):
 
 def available_plugins():
     """Return an iterable of registered plugin names."""
+    _ensure_plugins_loaded()
     return _registry.keys()
-
-
-# Import bundled plugins so that they register themselves with the registry.
-# Each plugin uses the register_plugin decorator at import time.
-try:  # pragma: no cover - import side effects are tested elsewhere
-    from . import blocks  # noqa: F401
-    from . import case_expr  # noqa: F401
-    from . import clauses  # noqa: F401
-    from . import comments  # noqa: F401
-    from . import cte  # noqa: F401
-    from . import create_table  # noqa: F401
-    from . import dialect_strictness  # noqa: F401
-    from . import joins  # noqa: F401
-    from . import list_controls  # noqa: F401
-    from . import penalties  # noqa: F401
-    from . import predicates  # noqa: F401
-    from . import spacing_casing  # noqa: F401
-    from . import subqueries  # noqa: F401
-except Exception:
-    # If a plugin fails to import we simply skip registration to keep
-    # compatibility with minimal environments.
-    pass

--- a/tests/test_blocks_plugin.py
+++ b/tests/test_blocks_plugin.py
@@ -1,5 +1,4 @@
 from sqlparse import plugins
-import sqlparse.plugins.blocks  # noqa: F401  ensure registration
 
 
 def _run(sql, options):

--- a/tests/test_case_expr_plugin.py
+++ b/tests/test_case_expr_plugin.py
@@ -1,4 +1,3 @@
-import sqlparse.plugins.case_expr  # ensure registration
 from sqlparse import plugins
 
 

--- a/tests/test_clauses_plugin.py
+++ b/tests/test_clauses_plugin.py
@@ -1,4 +1,3 @@
-import sqlparse.plugins.clauses  # noqa: F401
 from sqlparse import plugins
 
 

--- a/tests/test_comments_plugin.py
+++ b/tests/test_comments_plugin.py
@@ -1,5 +1,4 @@
 from sqlparse.plugins import get_plugin
-import sqlparse.plugins.comments  # ensure plugin registration
 
 
 def _format(sql, **opts):

--- a/tests/test_create_table_plugin.py
+++ b/tests/test_create_table_plugin.py
@@ -3,8 +3,6 @@ from sqlparse import plugins
 
 
 def get_plugin():
-    # ensure module import registers plugin
-    import sqlparse.plugins.create_table  # noqa: F401
     cls = plugins.get_plugin('create_table')
     return cls()
 

--- a/tests/test_penalties_plugin.py
+++ b/tests/test_penalties_plugin.py
@@ -1,8 +1,5 @@
 import sqlparse
-
-import sqlparse
 from sqlparse import plugins
-import sqlparse.plugins.penalties  # noqa: F401
 
 
 def _run_plugin(sql, penalties):

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -1,0 +1,18 @@
+import importlib
+from sqlparse import plugins
+
+
+def test_autodiscovery_without_explicit_import():
+    importlib.reload(plugins)
+    assert plugins.get_plugin('blocks') is not None
+
+
+def test_disable_plugin_via_env(monkeypatch):
+    monkeypatch.setenv('SQLPARSE_DISABLED_PLUGINS', 'blocks')
+    importlib.reload(plugins)
+    try:
+        assert plugins.get_plugin('blocks') is None
+    finally:
+        monkeypatch.delenv('SQLPARSE_DISABLED_PLUGINS', raising=False)
+        importlib.reload(plugins)
+

--- a/tests/test_plugin_joins.py
+++ b/tests/test_plugin_joins.py
@@ -4,7 +4,6 @@ import sqlparse
 import warnings
 
 from sqlparse import plugins
-import sqlparse.plugins.joins  # ensure registration
 
 
 def run_plugin(sql, opts):


### PR DESCRIPTION
## Summary
- dynamically discover bundled plugins and third-party entry points
- allow enabling/disabling plugins via environment variables
- document plugin discovery and entry point usage
- test automatic discovery and filtering

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*


------
https://chatgpt.com/codex/tasks/task_b_68a06ff815148326813b6aca2e11db2b